### PR TITLE
Fix html display on typography guide

### DIFF
--- a/src/documentation/markdown/Guides/Typography.md
+++ b/src/documentation/markdown/Guides/Typography.md
@@ -12,7 +12,7 @@ Roboto provides:
 - Includes additional sister fonts, like Roboto Mono. which can be paired nicely for the display of numbers, charts, code, etc. 
 
 ## Google Fonts Usage
-You can include the Roboto font, and the needed font weights, directly from the Google Fonts CDN by including the code snippet below between the <head> tags  your app / website:
+You can include the Roboto font, and the needed font weights, directly from the Google Fonts CDN by including the code snippet below between the &lt;head&gt; tags  your app / website:
 
 ```
 <link href="https://fonts.googleapis.com/css?family=Roboto:400,500,700" rel="stylesheet">


### PR DESCRIPTION
There is a bug on the typography guide where it renders part of a text as HTML. Then, the browser shows a warning on console:

```sh
Warning: validateDOMNesting(...): <head> cannot appear as a child of <p>.
```

And the text is truncated: 

```
You can include the Roboto font, and the needed font weights, directly from the Google Fonts CDN by including the code snippet below between the  tags your app / website:
```

This PR fixes this bug by escaping the HTML tags.