### PR TITLE
Fix forms guide indentation

### DIFF
--- a/src/documentation/markdown/Guides/Forms.md
+++ b/src/documentation/markdown/Guides/Forms.md
@@ -8,7 +8,7 @@ Within our design system, forms encompass many smaller components including text
 
 ## Inputs
 
-Text, email and password fields 
+Text, email and password fields
 
 ![Inputs](https://blobscdn.gitbook.com/v0/b/gitbook-28427.appspot.com/o/assets%2F-LFNym8ScnaWKWBQFWTw%2F-LG1fFqQHhO5GOKdxHQo%2F-LG1fo4cQO8mvASVcyR2%2Ftext-input%402x.png?alt=media&token=b5829563-249f-4b58-bc0a-608ba3bc9742)
 
@@ -24,76 +24,76 @@ Text, email and password fields
 
 ![Labels](https://blobscdn.gitbook.com/v0/b/gitbook-28427.appspot.com/o/assets%2F-LFNym8ScnaWKWBQFWTw%2F-LG1fFqQHhO5GOKdxHQo%2F-LG1gZow3tUzk1HV7Aqr%2Flabel-help-text%402x.png?alt=media&token=3c03d617-2750-4a3c-b279-cfc0219f6472)
 
- <InfoCard title='Do:' color='green'>
- - Labels should use title case, e.g. "Number of Employees". 
-   
- - Labels should be short and clear. 
-   
- - Help text should be used sparingly.
- </InfoCard>
- 
-
- <InfoCard title='Don't:' color='red'>
- - Don't use all caps for form labels, e.g. "COMPANY NAME"
-   
- - Don't use all lowercase text for form labels, e.g. "company name"
- </InfoCard>
- 
- 
- 
- ## Input Sizes
- 
- Just like buttons, our design system supports additional sizes for our form inputs:
- 
- ![Input sizes](https://blobscdn.gitbook.com/v0/b/gitbook-28427.appspot.com/o/assets%2F-LFNym8ScnaWKWBQFWTw%2F-LG1fFqQHhO5GOKdxHQo%2F-LG1glW_8IirCiM6812a%2Finput-dimensions%402x.png?alt=media&token=7b19a7ac-4c9d-4091-b833-ce3cb68c266b)
- 
- ### Larger
- 
- ![Larger Input](https://blobscdn.gitbook.com/v0/b/gitbook-28427.appspot.com/o/assets%2F-LFNym8ScnaWKWBQFWTw%2F-LG1fFqQHhO5GOKdxHQo%2F-LG1gvxwk3NT1vLm6X3c%2Finput-dimensions-larger%402x.png?alt=media&token=453896ac-6fcc-441a-af76-6000e2260cf5)
- 
- ### Normal (default)
- ![Normal Input](https://blobscdn.gitbook.com/v0/b/gitbook-28427.appspot.com/o/assets%2F-LFNym8ScnaWKWBQFWTw%2F-LG1fFqQHhO5GOKdxHQo%2F-LG1gymk-stz0T7GSKDV%2Finput-dimensions-normal%402x.png?alt=media&token=1ce72f8c-b1cb-4748-9aa7-eb73fef519ee)
- 
- ### Smaller
- ![Smaller Input](https://blobscdn.gitbook.com/v0/b/gitbook-28427.appspot.com/o/assets%2F-LFNym8ScnaWKWBQFWTw%2F-LG1fFqQHhO5GOKdxHQo%2F-LG1h04nvoUyKUmPopHY%2Finput-dimensions-small%402x.png?alt=media&token=1d3847bf-1533-4f1c-9d75-92afa6944c21)
- 
- ## Input States
- 
- ### Error State
- 
- ![Error Input](https://blobscdn.gitbook.com/v0/b/gitbook-28427.appspot.com/o/assets%2F-LFNym8ScnaWKWBQFWTw%2F-LG1fFqQHhO5GOKdxHQo%2F-LG1hHioFOq6x5PVsnP8%2Ftext-input-error-state%402x.png?alt=media&token=9089f0fc-4e29-40be-96aa-69cfc7618fe6)
- 
-  <InfoCard title='Do:' color='green'>
-  - Be clear and concise with error text.
-    
-  - Use the simplest language possible. 
-    
-  - Offer a direct solution if possible and/or link to additional information (FAQ, etc)
-  </InfoCard>
-  
- 
-  <InfoCard title='Don't:' color='red'>
-  - Don't use jargon or technical terms.
-    
-  - Don't display error or status codes. 
-  </InfoCard>
-  
-  ## Placeholder Text
-  
 <InfoCard title='Do:' color='green'>
-- Use placeholders in addition to labels to provide helpful context. 
-  
-- For example, you could add the placeholder text "Acme Inc." for an input labeled Company Name. 
+- Labels should use title case, e.g. "Number of Employees".
+
+- Labels should be short and clear.
+
+- Help text should be used sparingly.
 </InfoCard>
 
 
 <InfoCard title='Don't:' color='red'>
-- Use placeholders instead of a label. 
-  
-- Use a placeholder if the label is clear and common. For example, no placeholder text should be used for an input labeled "Email Address".  
+- Don't use all caps for form labels, e.g. "COMPANY NAME"
+
+- Don't use all lowercase text for form labels, e.g. "company name"
 </InfoCard>
-    
-    
+
+
+
+## Input Sizes
+
+Just like buttons, our design system supports additional sizes for our form inputs:
+
+![Input sizes](https://blobscdn.gitbook.com/v0/b/gitbook-28427.appspot.com/o/assets%2F-LFNym8ScnaWKWBQFWTw%2F-LG1fFqQHhO5GOKdxHQo%2F-LG1glW_8IirCiM6812a%2Finput-dimensions%402x.png?alt=media&token=7b19a7ac-4c9d-4091-b833-ce3cb68c266b)
+
+### Larger
+
+![Larger Input](https://blobscdn.gitbook.com/v0/b/gitbook-28427.appspot.com/o/assets%2F-LFNym8ScnaWKWBQFWTw%2F-LG1fFqQHhO5GOKdxHQo%2F-LG1gvxwk3NT1vLm6X3c%2Finput-dimensions-larger%402x.png?alt=media&token=453896ac-6fcc-441a-af76-6000e2260cf5)
+
+### Normal (default)
+![Normal Input](https://blobscdn.gitbook.com/v0/b/gitbook-28427.appspot.com/o/assets%2F-LFNym8ScnaWKWBQFWTw%2F-LG1fFqQHhO5GOKdxHQo%2F-LG1gymk-stz0T7GSKDV%2Finput-dimensions-normal%402x.png?alt=media&token=1ce72f8c-b1cb-4748-9aa7-eb73fef519ee)
+
+### Smaller
+![Smaller Input](https://blobscdn.gitbook.com/v0/b/gitbook-28427.appspot.com/o/assets%2F-LFNym8ScnaWKWBQFWTw%2F-LG1fFqQHhO5GOKdxHQo%2F-LG1h04nvoUyKUmPopHY%2Finput-dimensions-small%402x.png?alt=media&token=1d3847bf-1533-4f1c-9d75-92afa6944c21)
+
+## Input States
+
+### Error State
+
+![Error Input](https://blobscdn.gitbook.com/v0/b/gitbook-28427.appspot.com/o/assets%2F-LFNym8ScnaWKWBQFWTw%2F-LG1fFqQHhO5GOKdxHQo%2F-LG1hHioFOq6x5PVsnP8%2Ftext-input-error-state%402x.png?alt=media&token=9089f0fc-4e29-40be-96aa-69cfc7618fe6)
+
+<InfoCard title='Do:' color='green'>
+- Be clear and concise with error text.
+
+- Use the simplest language possible.
+
+- Offer a direct solution if possible and/or link to additional information (FAQ, etc)
+</InfoCard>
+
+
+<InfoCard title='Don't:' color='red'>
+- Don't use jargon or technical terms.
+
+- Don't display error or status codes.
+</InfoCard>
+
+## Placeholder Text
+
+<InfoCard title='Do:' color='green'>
+- Use placeholders in addition to labels to provide helpful context.
+
+- For example, you could add the placeholder text "Acme Inc." for an input labeled Company Name.
+</InfoCard>
+
+
+<InfoCard title='Don't:' color='red'>
+- Use placeholders instead of a label.
+
+- Use a placeholder if the label is clear and common. For example, no placeholder text should be used for an input labeled "Email Address".
+</InfoCard>
+
+
 ## Resources
 [​Figma​](https://www.figma.com/file/KESDkHWaJkldpVOEtiKhueUb/BDS-Forms)
 


### PR DESCRIPTION
Bug example:

<img width="806" alt="screen shot 2018-12-19 at 12 34 03 pm" src="https://user-images.githubusercontent.com/782333/50226484-6cf6e200-038a-11e9-904d-efa6097a5dfb.png">

<img width="793" alt="screen shot 2018-12-19 at 12 34 15 pm" src="https://user-images.githubusercontent.com/782333/50226493-71bb9600-038a-11e9-8b7b-fc4bc0805a5f.png">
