### PR TITLE
add Text and Text Input components

### DIFF
--- a/src/components/Input/Input.jsx
+++ b/src/components/Input/Input.jsx
@@ -1,0 +1,75 @@
+import React from 'react';
+
+import PropTypes from 'prop-types';
+import * as Styles from './style';
+import { Warning } from '../Icon';
+import Text from '../Text';
+
+const Input = ({
+  disabled,
+  hasError,
+  help,
+  label,
+  name,
+  onChange,
+  placeholder,
+  size,
+  type,
+  value,
+}) => (
+  <div>
+    {label.length > 0 && <Text htmlFor={name} type='label'>{label}</Text>}
+    <Styles.InputStyled
+      disabled={disabled}
+      hasError={hasError}
+      name={name}
+      onChange={onChange}
+      placeholder={placeholder}
+      type={type}
+      size={size}
+      value={value}
+    />
+    {help.length > 0 && (
+      <Text type='help' htmlFor={name} hasError={hasError}>
+        {hasError && <Warning size="small" />}
+        {`${hasError ? ' ' : ''}${help}`}
+      </Text>
+    )}
+  </div>
+);
+
+Input.propTypes = {
+  /** It disables the input field. </i> */
+  disabled: PropTypes.bool,
+  /** It colors the field in red. */
+  hasError: PropTypes.bool,
+  /** It adds an help text below the input box. */
+  help: PropTypes.string,
+  /** It adds a label on top of the input box. */
+  label: PropTypes.string,
+  /** It's the name of the input. */
+  name: PropTypes.string.isRequired,
+  /** It's the placeholder value of the input. */
+  placeholder: PropTypes.string,
+  /** The onChange event */
+  onChange: PropTypes.func.isRequired,
+  /** This is the vertical size of the input field, can be `small`, `regular`, or `tall` */
+  size: PropTypes.string,
+  /** The type of the input */
+  type: PropTypes.string,
+  /** The value of the input */
+  value: PropTypes.string,
+};
+
+Input.defaultProps = {
+  disabled: false,
+  hasError: false,
+  help: '',
+  label: '',
+  placeholder: '',
+  size: 'regular',
+  type: 'text',
+  value: undefined,
+}
+
+export default Input;

--- a/src/components/Input/Input.spec.js
+++ b/src/components/Input/Input.spec.js
@@ -1,0 +1,7 @@
+/* eslint-disable react/jsx-filename-extension */
+import snap from 'jest-auto-snapshots';
+import 'jest-styled-components';
+
+import Input from './Input';
+
+snap(Input, './Input.jsx');

--- a/src/components/Input/__snapshots__/Input.spec.js.snap
+++ b/src/components/Input/__snapshots__/Input.spec.js.snap
@@ -1,0 +1,116 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`jest-auto-snapshots > Input Matches snapshot when boolean prop "disabled" is set to: "false" 1`] = `
+<div>
+  <Text
+    hasError={false}
+    htmlFor="jest-auto-snapshots String Fixture"
+    light={false}
+    type="label"
+  >
+    jest-auto-snapshots String Fixture
+  </Text>
+  <ForwardRef
+    disabled={false}
+    hasError={true}
+    name="jest-auto-snapshots String Fixture"
+    onChange={[MockFunction]}
+    placeholder="jest-auto-snapshots String Fixture"
+    size="jest-auto-snapshots String Fixture"
+    type="jest-auto-snapshots String Fixture"
+    value="jest-auto-snapshots String Fixture"
+  />
+  <Text
+    hasError={true}
+    htmlFor="jest-auto-snapshots String Fixture"
+    light={false}
+    type="help"
+  >
+    <Warning
+      color="grayDark"
+      size="small"
+    />
+     jest-auto-snapshots String Fixture
+  </Text>
+</div>
+`;
+
+exports[`jest-auto-snapshots > Input Matches snapshot when boolean prop "hasError" is set to: "false" 1`] = `
+<div>
+  <Text
+    hasError={false}
+    htmlFor="jest-auto-snapshots String Fixture"
+    light={false}
+    type="label"
+  >
+    jest-auto-snapshots String Fixture
+  </Text>
+  <ForwardRef
+    disabled={true}
+    hasError={false}
+    name="jest-auto-snapshots String Fixture"
+    onChange={[MockFunction]}
+    placeholder="jest-auto-snapshots String Fixture"
+    size="jest-auto-snapshots String Fixture"
+    type="jest-auto-snapshots String Fixture"
+    value="jest-auto-snapshots String Fixture"
+  />
+  <Text
+    hasError={false}
+    htmlFor="jest-auto-snapshots String Fixture"
+    light={false}
+    type="help"
+  >
+    jest-auto-snapshots String Fixture
+  </Text>
+</div>
+`;
+
+exports[`jest-auto-snapshots > Input Matches snapshot when passed all props 1`] = `
+<div>
+  <Text
+    hasError={false}
+    htmlFor="jest-auto-snapshots String Fixture"
+    light={false}
+    type="label"
+  >
+    jest-auto-snapshots String Fixture
+  </Text>
+  <ForwardRef
+    disabled={true}
+    hasError={true}
+    name="jest-auto-snapshots String Fixture"
+    onChange={[MockFunction]}
+    placeholder="jest-auto-snapshots String Fixture"
+    size="jest-auto-snapshots String Fixture"
+    type="jest-auto-snapshots String Fixture"
+    value="jest-auto-snapshots String Fixture"
+  />
+  <Text
+    hasError={true}
+    htmlFor="jest-auto-snapshots String Fixture"
+    light={false}
+    type="help"
+  >
+    <Warning
+      color="grayDark"
+      size="small"
+    />
+     jest-auto-snapshots String Fixture
+  </Text>
+</div>
+`;
+
+exports[`jest-auto-snapshots > Input Matches snapshot when passed only required props 1`] = `
+<div>
+  <ForwardRef
+    disabled={false}
+    hasError={false}
+    name="jest-auto-snapshots String Fixture"
+    onChange={[MockFunction]}
+    placeholder=""
+    size="regular"
+    type="text"
+  />
+</div>
+`;

--- a/src/components/Input/index.js
+++ b/src/components/Input/index.js
@@ -1,0 +1,1 @@
+export { default } from './Input';

--- a/src/components/Input/style.js
+++ b/src/components/Input/style.js
@@ -1,0 +1,62 @@
+import styled from 'styled-components';
+import {
+  blue,
+  gray,
+  grayLight,
+  grayDarker,
+  grayDark,
+  red,
+  redLight,
+  white,
+} from '../style/colors';
+import {
+  fontFamily,
+  fontSize,
+  fontWeight,
+  lineHeight,
+} from '../style/fonts';
+
+export const InputStyled = styled.input`
+  background: ${ ({ hasError }) => hasError ? redLight : white };
+  border-radius: 4px;
+  border: 1px solid ${ ({ hasError }) => hasError ? red : grayLight };
+  box-sizing: border-box;
+  color: ${ ({ hasError }) => hasError ? red : grayDarker };
+  font-family: ${fontFamily};
+  font-size: ${fontSize};
+  font-weight: ${fontWeight};
+  line-height: ${lineHeight};
+  padding: ${ ({ size }) => {
+    switch(size) {
+      case 'small':
+        return '5px 8px 4px 8px';
+      case 'tall':
+        return '13px 16px 12px 16px';
+      default:
+        return '9px 8px 8px 8px';
+    }
+  }};
+  width: 100%;
+  cursor: pointer;
+
+  &::placeholder {
+    color: ${gray};
+  }
+
+  &:focus {
+    border: 1px solid ${ ({ hasError }) => hasError ? red : blue };
+    box-shadow: 0px 0px 0px 3px ${ ({ hasError }) => hasError ? "#F3AFB9" : "#ABB7FF" };
+    outline: none;
+  }
+
+  &:disabled {
+    background: ${grayLight};
+    border: 1px solid ${grayLight};
+    color: ${grayDark};
+    cursor: not-allowed;
+
+    &::placeholder {
+      color: ${gray};
+    }
+  }
+`;

--- a/src/components/Text/Text.jsx
+++ b/src/components/Text/Text.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+
+import PropTypes from 'prop-types';
+import * as Styles from './style';
+
+const Text = ({ children, type, ...props }) => {
+  switch (type) {
+    case 'h1':
+      return (<Styles.H1>{children}</Styles.H1>);
+    case 'h2':
+      return (<Styles.H2>{children}</Styles.H2>);
+    case 'h3':
+      return (<Styles.H3>{children}</Styles.H3>);
+    case 'p':
+      return (<Styles.Paragraph>{children}</Styles.Paragraph>);
+    case 'label':
+      return (<Styles.Label {...props}>{children}</Styles.Label>);
+    case 'help':
+      return (<Styles.Help {...props}>{children}</Styles.Help>);
+    default:
+      return (<Styles.Span>{children}</Styles.Span>);
+  }
+};
+
+Text.propTypes = {
+  /** The actual text content. */
+  children: PropTypes.node,
+  /** It changes the color of the text to red. <br><i>This is only used for `help`</i>. */
+  hasError: PropTypes.bool,
+  /** It's the name of the input it refers to. <br><i>This is only used for `label`.</i> */
+  htmlFor: PropTypes.string,
+  /** It change the color of the text. <br><i>This is only used for `label`</i>. */
+  light: PropTypes.bool,
+  /** The type can be: `h1`, `h2`, `h3`, `p`, `label`, `help`. <br><i>If omitted will return a `span`</i> */
+  type: PropTypes.string,
+};
+
+Text.defaultProps = {
+  children: undefined,
+  hasError: false,
+  htmlFor: undefined,
+  light: false,
+  type: 'span',
+}
+
+export default Text;

--- a/src/components/Text/Text.spec.js
+++ b/src/components/Text/Text.spec.js
@@ -1,0 +1,7 @@
+/* eslint-disable react/jsx-filename-extension */
+import snap from 'jest-auto-snapshots';
+import 'jest-styled-components';
+
+import Text from './Text';
+
+snap(Text, './Text.jsx');

--- a/src/components/Text/__snapshots__/Text.spec.js.snap
+++ b/src/components/Text/__snapshots__/Text.spec.js.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`jest-auto-snapshots > Text Matches snapshot when boolean prop "hasError" is set to: "false" 1`] = `
+<ForwardRef>
+  <NodeFixture />
+</ForwardRef>
+`;
+
+exports[`jest-auto-snapshots > Text Matches snapshot when boolean prop "light" is set to: "false" 1`] = `
+<ForwardRef>
+  <NodeFixture />
+</ForwardRef>
+`;
+
+exports[`jest-auto-snapshots > Text Matches snapshot when passed all props 1`] = `
+<ForwardRef>
+  <NodeFixture />
+</ForwardRef>
+`;

--- a/src/components/Text/index.js
+++ b/src/components/Text/index.js
@@ -1,0 +1,1 @@
+export { default } from './Text';

--- a/src/components/Text/style.js
+++ b/src/components/Text/style.js
@@ -1,0 +1,71 @@
+import styled from 'styled-components';
+import {
+  grayDarker,
+  grayDark,
+  red,
+} from '../style/colors';
+import {
+  fontFamily,
+  fontSize,
+  fontWeight,
+  fontWeightBold,
+  fontWeightMedium,
+  lineHeight,
+} from '../style/fonts';
+
+export const Span = styled.span`
+  color: inherit;
+  font-family: ${fontFamily};
+  font-size: inherit;
+  font-weight: inherit;
+  line-height: inherit;
+`;
+
+export const Paragraph = styled.p`
+  color: ${grayDarker};
+  font-family: ${fontFamily};
+  font-size: ${fontSize};
+  font-weight: ${fontWeight};
+  line-height: 20px;
+`;
+
+export const H1 = styled.h1`
+  color: ${grayDarker};
+  font-family: ${fontFamily};
+  font-size: 32px;
+  font-weight: ${fontWeightBold};
+  line-height: 44px;
+`;
+
+export const H2 = styled.h2`
+  color: ${grayDarker};
+  font-family: ${fontFamily};
+  font-size: 24px;
+  font-weight: ${fontWeightBold};
+  line-height: 34px;
+`;
+
+export const H3 = styled.h3`
+  color: ${grayDarker};
+  font-family: ${fontFamily};
+  font-size: 18px;
+  font-weight: ${fontWeightBold};
+  line-height: 28px;
+`;
+
+export const Label = styled.label`
+  color: ${({ light }) => light ? grayDark : grayDarker };
+  font-family: ${fontFamily};
+  font-size: ${fontSize};
+  font-weight: ${fontWeightMedium};
+  line-height: ${lineHeight};
+`;
+
+export const Help = styled.label`
+  color: ${({ hasError }) => hasError ? red : grayDarker };
+  font-family: ${fontFamily};
+  font-size: 12px;
+  font-weight: ${fontWeightMedium};
+  line-height: ${lineHeight};
+`;
+

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,3 +1,4 @@
 export { default as Button } from './Button';
 export { default as Select } from './Select';
 export { default as ButtonSelect } from './ButtonSelect';
+export { default as Text } from './Text';

--- a/src/components/style/colors.js
+++ b/src/components/style/colors.js
@@ -5,6 +5,7 @@ export const purple = '#9C2BFF';
 export const pink = '#D925AC';
 export const teal = '#00C8CF';
 export const red = '#E0364F';
+export const redLight = '#FDF2F4';
 export const orange = '#FF702C';
 export const yellow = '#FADE2A';
 export const green = '#87C211';

--- a/src/components/style/fonts.js
+++ b/src/components/style/fonts.js
@@ -8,5 +8,6 @@ export const fontWeightLight = 300;
 export const fontWeight = 400; // Normal
 export const fontWeightMedium = 500;
 export const fontWeightSemiBold = 600;
+export const fontWeightBold = 700;
 
 export const lineHeight = 1.5;

--- a/src/documentation/examples/Input/option/Default.jsx
+++ b/src/documentation/examples/Input/option/Default.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import Input from '@bufferapp/ui/Input';
+
+/** Input */
+export default function ExampleInput() {
+  return (
+    <Input
+      type='input'
+      onChange={()=>{}}
+      name='foo'
+      placeholder='placeholder text'
+    />
+  );
+}

--- a/src/documentation/examples/Input/option/WithHelp.jsx
+++ b/src/documentation/examples/Input/option/WithHelp.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import Input from '@bufferapp/ui/Input';
+
+/** Input with help text */
+export default function ExampleInput() {
+  return (
+    <Input
+      onChange={()=>{}}
+      name='foo'
+      help="this is an help text"
+      placeholder="placeholder text"
+    />
+  );
+}

--- a/src/documentation/examples/Input/option/WithLabel.jsx
+++ b/src/documentation/examples/Input/option/WithLabel.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import Input from '@bufferapp/ui/Input';
+
+/** Input with label text */
+export default function ExampleInput() {
+  return (
+    <Input
+      onChange={()=>{}}
+      name='foo'
+      label="this is a label text"
+      placeholder="placeholder text"
+    />
+  );
+}

--- a/src/documentation/examples/Input/option/WithValue.jsx
+++ b/src/documentation/examples/Input/option/WithValue.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import Input from '@bufferapp/ui/Input';
+
+/** Input with value */
+export default function ExampleInput() {
+  return (
+    <Input
+      onChange={()=>{}}
+      name='foo'
+      placeholder='placeholder text'
+      value='This is an input with a value'
+    />
+  );
+}

--- a/src/documentation/examples/Input/size/Regular.jsx
+++ b/src/documentation/examples/Input/size/Regular.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import Input from '@bufferapp/ui/Input';
+
+/** Regular input */
+export default function ExampleInput() {
+  return (
+    <Input
+      type='input'
+      onChange={()=>{}}
+      name='foo'
+      placeholder='placeholder text'
+    />
+  );
+}

--- a/src/documentation/examples/Input/size/Small.jsx
+++ b/src/documentation/examples/Input/size/Small.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import Input from '@bufferapp/ui/Input';
+
+/** Small input */
+export default function ExampleInput() {
+  return (
+    <Input
+      type='input'
+      onChange={()=>{}}
+      name='foo'
+      placeholder='placeholder text'
+      size='small'
+    />
+  );
+}

--- a/src/documentation/examples/Input/size/Tall.jsx
+++ b/src/documentation/examples/Input/size/Tall.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import Input from '@bufferapp/ui/Input';
+
+/** Tall input */
+export default function ExampleInput() {
+  return (
+    <Input
+      type='input'
+      onChange={()=>{}}
+      name='foo'
+      placeholder='placeholder text'
+      size='tall'
+    />
+  );
+}

--- a/src/documentation/examples/Input/state/Disabled.jsx
+++ b/src/documentation/examples/Input/state/Disabled.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import Input from '@bufferapp/ui/Input';
+
+/** Input disabled */
+export default function ExampleInput() {
+  return (
+    <Input
+      type='input'
+      onChange={()=>{}}
+      name='foo'
+      placeholder='a disabled text input'
+      disabled
+    />
+  );
+}

--- a/src/documentation/examples/Input/state/WithError.jsx
+++ b/src/documentation/examples/Input/state/WithError.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import Input from '@bufferapp/ui/Input';
+
+/** Input with error */
+export default function ExampleInput() {
+  return (
+    <Input
+      type='input'
+      onChange={()=>{}}
+      name='foo'
+      placeholder='placeholder text'
+      hasError
+      value='this is an input with an error'
+    />
+  );
+}

--- a/src/documentation/examples/Input/state/WithErrorAndHelp.jsx
+++ b/src/documentation/examples/Input/state/WithErrorAndHelp.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import Input from '@bufferapp/ui/Input';
+
+/** Input with error and help text */
+export default function ExampleInput() {
+  return (
+    <Input
+      onChange={()=>{}}
+      name='foo'
+      placeholder="placeholder text"
+      help="help text"
+      hasError
+      value='this is an input with an error'
+    />
+  );
+}

--- a/src/documentation/examples/Text/basic/Paragraph.jsx
+++ b/src/documentation/examples/Text/basic/Paragraph.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import Text from '@bufferapp/ui/Text';
+
+/** Paragraph  */
+export default function ExampleText() {
+  return (
+    <Text type='p'>This is a paragraph</Text>
+  );
+}

--- a/src/documentation/examples/Text/basic/Span.jsx
+++ b/src/documentation/examples/Text/basic/Span.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import Text from '@bufferapp/ui/Text';
+
+/** Span (default) */
+export default function ExampleText() {
+  return (
+    <Text>This is a span</Text>
+  );
+}

--- a/src/documentation/examples/Text/heading/H1.jsx
+++ b/src/documentation/examples/Text/heading/H1.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import Text from '@bufferapp/ui/Text';
+
+/** H1 Heading */
+export default function ExampleText() {
+  return (
+    <Text type='h1'>This is a H1 Heading</Text>
+  );
+}

--- a/src/documentation/examples/Text/heading/H2.jsx
+++ b/src/documentation/examples/Text/heading/H2.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import Text from '@bufferapp/ui/Text';
+
+/** H2 Heading */
+export default function ExampleText() {
+  return (
+    <Text type='h2'>This is a H2 Heading</Text>
+  );
+}

--- a/src/documentation/examples/Text/heading/H3.jsx
+++ b/src/documentation/examples/Text/heading/H3.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import Text from '@bufferapp/ui/Text';
+
+/** H3 Heading */
+export default function ExampleText() {
+  return (
+    <Text type='h3'>This is a H3 Heading</Text>
+  );
+}

--- a/src/documentation/examples/Text/label/Help.jsx
+++ b/src/documentation/examples/Text/label/Help.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import Text from '@bufferapp/ui/Text';
+
+/** Help */
+export default function ExampleText() {
+  return (
+    <Text
+      htmlFor="foo"
+      type='help'
+    >
+      This is a light colored Label
+    </Text>
+  );
+}

--- a/src/documentation/examples/Text/label/HelpWithError.jsx
+++ b/src/documentation/examples/Text/label/HelpWithError.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import Text from '@bufferapp/ui/Text';
+
+/** Help with error */
+export default function ExampleText() {
+  return (
+    <Text
+      htmlFor="foo"
+      type='help'
+      hasError
+    >
+      This is a light colored Label
+    </Text>
+  );
+}

--- a/src/documentation/examples/Text/label/Label.jsx
+++ b/src/documentation/examples/Text/label/Label.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import Text from '@bufferapp/ui/Text';
+
+/** Label */
+export default function ExampleText() {
+  return (
+    <Text
+      htmlFor="foo"
+      type='label'
+    >
+      This is a Label
+    </Text>
+  );
+}

--- a/src/documentation/examples/Text/label/LabelLight.jsx
+++ b/src/documentation/examples/Text/label/LabelLight.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import Text from '@bufferapp/ui/Text';
+
+/** Label (light color) */
+export default function ExampleText() {
+  return (
+    <Text
+      htmlFor="foo"
+      type='label'
+      light
+    >
+      This is a light colored Label
+    </Text>
+  );
+}


### PR DESCRIPTION
This is a first pass to the Text and Input components.
It implements all the elements as defined in the [BDS Typography specification](https://www.figma.com/file/Zlx2ZAx6xxJwYtXUORQYb7TK/BDS-Typography?node-id=3%3A0&viewport=1350%2C965%2C2), and the text inputs from [BDS Input specification](https://www.figma.com/file/KESDkHWaJkldpVOEtiKhueUb/BDS-Forms?node-id=81%3A157&viewport=731%2C-42%2C1.02284).

## Text Components
![image](https://user-images.githubusercontent.com/992920/52157586-f1ed4080-2644-11e9-955c-f1fc020a0206.png)
![image](https://user-images.githubusercontent.com/992920/52157595-0e897880-2645-11e9-9448-95aa3be9a1e3.png)


## Text Input fields
![image](https://user-images.githubusercontent.com/992920/52157601-22cd7580-2645-11e9-8aff-8f9ca387d546.png)
![image](https://user-images.githubusercontent.com/992920/52158085-83f74800-2649-11e9-8825-00d4aa80c91c.png)


_Note: This implements ony text based inputs. Will add checkbox and toggle in a different pr 😄._
