### PR TITLE
Task/delay search focus

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "gen:docs-watch": "npm run gen:docs -- --watch",
     "build:docs": "node scripts/build.js",
     "lint": "./node_modules/eslint/bin/eslint.js .",
-    "test": "jest -u && npm run lint",
+    "test": "jest && npm run lint",
     "test-update": "NODE_ENV=production jest --no-coverage -u",
     "test-watch": "NODE_ENV=production jest --no-coverage --watch",
     "predeploy:docs": "npm run build:docs",

--- a/src/components/Search/Search.jsx
+++ b/src/components/Search/Search.jsx
@@ -11,7 +11,7 @@ export default class Search extends React.Component {
 
   componentDidUpdate(prevProps) {
     if(prevProps.isOpen !== this.props.isOpen){
-      this.inputRef.focus();
+      setTimeout(()=> this.inputRef.focus(), 50)
     }
   }
 

--- a/src/components/Select/Select.jsx
+++ b/src/components/Select/Select.jsx
@@ -244,7 +244,7 @@ export default class Select extends React.Component {
 
   onClose = () => {
     const { onClose } = this.props;
-    this.setState({ isOpen: false, isFiltering: false }, onClose());
+    this.setState({ isOpen: false, isFiltering: false }, onClose && onClose());
   };
 
   getItemId = item => {

--- a/src/components/Select/Select.jsx
+++ b/src/components/Select/Select.jsx
@@ -243,7 +243,8 @@ export default class Select extends React.Component {
   };
 
   onClose = () => {
-    this.setState({ isOpen: false, isFiltering: false });
+    const { onClose } = this.props;
+    this.setState({ isOpen: false, isFiltering: false }, onClose());
   };
 
   getItemId = item => {
@@ -416,7 +417,10 @@ Select.propTypes = {
   tooltip: PropTypes.string,
 
   /** Should the component be opened */
-  isOpen: PropTypes.bool
+  isOpen: PropTypes.bool,
+
+  /** Callback to be called when the Select menu gets closed */
+  onClose: PropTypes.func
 };
 
 Select.defaultProps = {
@@ -435,5 +439,6 @@ Select.defaultProps = {
   shortcutsEnabled: true,
   searchPlaceholder: 'Search',
   tooltip: undefined,
-  isOpen: null
+  isOpen: null,
+  onClose: undefined
 };


### PR DESCRIPTION
Heya @gomezjuliana ,

Here's the PR to fix the issues we've been seeing with Selects in Reply 😊 . Here's what I did:
- added a small delay before focusing the Search input in order to prevent the hotkey (used to open the Select) to be added to the input
- added an optional `onClose` callback prop to the Select that we can call from Reply when the Select is closed. This one is needed because we are now closing the Selects from the component itself and not from the apps (we have an `esc` keyboard event listener). However, we also need to set the focus in Reply whenever a Select is closed, so we'll need to pass a function here in order to do that. I'll add some comments in the Reply's PR on how to handle this there 🤗 

