### PR TITLE
Fix/exports

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -13,9 +13,11 @@ fi
 newVersion=$1
 echo -e $BLUE"Publishing a new" $newVersion "version"$NC
 
-npm version $newVersion && \
+git checkout master && \
+  npm version $newVersion && \
   npm run build:lib && \
   cd ./lib && \
   npm publish && \
   cd ../ &&\
+  git push \
   npm run deploy:docs

--- a/src/components/Select/__snapshots__/Select.spec.js.snap
+++ b/src/components/Select/__snapshots__/Select.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`jest-auto-snapshots > Select Matches snapshot when array prop "items" has one item: "[object Object]" 1`] = `
 <ForwardRef
-  data-tip="jest-auto-snapshots String Fixture"
+  data-tip=""
   isSplit={true}
   onClick={[Function]}
   onKeyUp={[Function]}
@@ -115,7 +115,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "disabl
 
 exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "hasIconOnly" is set to: "false" 1`] = `
 <ForwardRef
-  data-tip="jest-auto-snapshots String Fixture"
+  data-tip=""
   isSplit={true}
   onClick={[Function]}
   onKeyUp={[Function]}
@@ -171,7 +171,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "hasIco
 
 exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "hasSearch" is set to: "false" 1`] = `
 <ForwardRef
-  data-tip="jest-auto-snapshots String Fixture"
+  data-tip=""
   isSplit={true}
   onClick={[Function]}
   onKeyUp={[Function]}
@@ -218,7 +218,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "hasSea
 
 exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "isOpen" is set to: "false" 1`] = `
 <ForwardRef
-  data-tip="jest-auto-snapshots String Fixture"
+  data-tip=""
   isSplit={true}
   onClick={[Function]}
   onKeyUp={[Function]}
@@ -274,7 +274,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "isOpen
 
 exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "isSplit" is set to: "false" 1`] = `
 <ForwardRef
-  data-tip="jest-auto-snapshots String Fixture"
+  data-tip=""
   isSplit={false}
   onClick={[Function]}
   onKeyUp={[Function]}
@@ -322,7 +322,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "isSpli
 
 exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "multiSelect" is set to: "false" 1`] = `
 <ForwardRef
-  data-tip="jest-auto-snapshots String Fixture"
+  data-tip=""
   isSplit={true}
   onClick={[Function]}
   onKeyUp={[Function]}
@@ -378,7 +378,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "multiS
 
 exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "shortcutsEnabled" is set to: "false" 1`] = `
 <ForwardRef
-  data-tip="jest-auto-snapshots String Fixture"
+  data-tip=""
   isSplit={true}
   onClick={[Function]}
   onKeyUp={[Function]}
@@ -434,7 +434,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "shortc
 
 exports[`jest-auto-snapshots > Select Matches snapshot when passed all props 1`] = `
 <ForwardRef
-  data-tip="jest-auto-snapshots String Fixture"
+  data-tip=""
   isSplit={true}
   onClick={[Function]}
   onKeyUp={[Function]}

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,5 +1,4 @@
 export { default as Button } from './Button';
 export { default as Select } from './Select';
-export { default as ButtonSelect } from './ButtonSelect';
 export { default as AppShell } from './AppShell';
 export { default as Text } from './Text';


### PR DESCRIPTION
This removes `ButtonSelect` from the exports, as it was breaking the import flow.

It also updates the publish script so that it ensures we are on **master** branch, and that the updated version is pushed to `origin/master` after publishing.