### PR TITLE
Fix/appshell render

### DIFF
--- a/src/components/AppShell/AppShell.jsx
+++ b/src/components/AppShell/AppShell.jsx
@@ -7,15 +7,15 @@ import { AppShellStyled, Wrapper, SidebarWrapper, ContentWrapper } from './style
 /**
  * The AppShell component is a general purpose wrapper for all of our applications.
  */
-const AppShell = ({ user, sidebar: SidebarComponent, content: ContentComponent }) => (
+const AppShell = ({ user, sidebar, content }) => (
   <AppShellStyled>
     <NavBar user={user} />
     <Wrapper>
       <SidebarWrapper>
-        <SidebarComponent />
+        {sidebar}
       </SidebarWrapper>
       <ContentWrapper>
-        <ContentComponent />
+        {content}
       </ContentWrapper>
     </Wrapper>
   </AppShellStyled>
@@ -34,8 +34,8 @@ AppShell.propTypes = {
       onItemClick: PropTypes.func,
     })).isRequired,
   }).isRequired,
-  sidebar: PropTypes.func.isRequired,
-  content: PropTypes.func.isRequired,
+  sidebar: PropTypes.node.isRequired,
+  content: PropTypes.node.isRequired,
 };
 
 export default AppShell;

--- a/src/components/AppShell/__snapshots__/AppShell.spec.js.snap
+++ b/src/components/AppShell/__snapshots__/AppShell.spec.js.snap
@@ -22,10 +22,10 @@ exports[`jest-auto-snapshots > AppShell Matches snapshot when passed only requir
   />
   <ForwardRef>
     <ForwardRef>
-      <mockConstructor />
+      <NodeFixture />
     </ForwardRef>
     <ForwardRef>
-      <mockConstructor />
+      <NodeFixture />
     </ForwardRef>
   </ForwardRef>
 </ForwardRef>

--- a/src/components/Select/Select.jsx
+++ b/src/components/Select/Select.jsx
@@ -27,7 +27,7 @@ export default class Select extends React.Component {
   static getDerivedStateFromProps(props, state) {
     if (
       props.items &&
-      props.items.length !== state.items.length &&
+      props.items !== state.items &&
       !state.isFiltering
     ) {
       return { items: props.items };


### PR DESCRIPTION
Heya team,

I've changed the `content` and `sidebar` props in the `AppShell` to be components, instead of functions. The reason for this is that we were ending up in a render loop in Reply when using functions, as every time any prop would change, it would call the render, which triggered the function, mounted the components again and caused the props to get updated again 😅 .

Not sure if there was a specific reason for using a function here. In case there was, please let me know, happy to think though this some more 🙌 
