### PR TITLE
fix comparing select items in getDerivedStateFromProps

### DIFF
--- a/src/components/Select/Select.jsx
+++ b/src/components/Select/Select.jsx
@@ -18,6 +18,15 @@ import Search from '../Search/Search';
 
 /** Select component that opens a popup menu on click and displays items that can be selected */
 export default class Select extends React.Component {
+  static sameItems = (itemsA, itemsB) => (
+    itemsA.length === itemsB.length &&
+    itemsA.every(
+      (el, ix) =>
+        el.id === itemsB[ix].id  &&
+        el.title === itemsB[ix].title
+    )
+  );
+
   state = {
     isOpen: this.props.isOpen,
     items: this.props.items || [],
@@ -27,13 +36,14 @@ export default class Select extends React.Component {
   static getDerivedStateFromProps(props, state) {
     if (
       props.items &&
-      JSON.stringify(props.items) !== JSON.stringify(state.items) &&
+      !Select.sameItems(props.items, state.items) &&
       !state.isFiltering
     ) {
       return { items: props.items };
     }
     return null;
   }
+
 
   componentDidMount() {
     // When the selector is open and users click anywhere on the page,


### PR DESCRIPTION
Since using `JSON.stringify` caused issues in items that had a more complex structure, this PR compares the arrays by comparing their length and id, title. If the arrays are the same length and their elements have the same id and title, they are considered equal.

Curious how this feels to you all?

cc @federicoweber @ssvmvss @gomezjuliana 