### PR TITLE
adds a custom margin prop to Selects for customButtons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufferapp/ui-template",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "engines": {
     "node": ">=4.0.0"
   },

--- a/src/components/Select/Select.jsx
+++ b/src/components/Select/Select.jsx
@@ -18,6 +18,12 @@ import Search from '../Search/Search';
 
 /** Select component that opens a popup menu on click and displays items that can be selected */
 export default class Select extends React.Component {
+  static sameItems = (itemsA, itemsB) =>
+    itemsA.length === itemsB.length &&
+    itemsA.every(
+      (el, ix) => el.id === itemsB[ix].id && el.title === itemsB[ix].title
+    );
+
   state = {
     isOpen: this.props.isOpen,
     items: this.props.items || [],
@@ -27,7 +33,7 @@ export default class Select extends React.Component {
   static getDerivedStateFromProps(props, state) {
     if (
       props.items &&
-      JSON.stringify(props.items) !== JSON.stringify(state.items) &&
+      !Select.sameItems(props.items, state.items) &&
       !state.isFiltering
     ) {
       return { items: props.items };
@@ -331,10 +337,10 @@ export default class Select extends React.Component {
     const {
       position,
       hasSearch,
-      customButton,
       keyMap,
       searchPlaceholder,
       hasIconOnly,
+      marginTop,
     } = this.props;
     const { isOpen, hoveredItem, items } = this.state;
 
@@ -342,8 +348,8 @@ export default class Select extends React.Component {
       <SelectStyled
         isOpen={isOpen}
         position={position}
-        isMenu={!!customButton}
         hasIconOnly={hasIconOnly}
+        marginTop={marginTop}
       >
         {hasSearch && (
           <div id="searchInput" ref={node => (this.searchInputNode = node)}>
@@ -475,6 +481,9 @@ Select.propTypes = {
 
   /** Does the button have only an icon and no label */
   hasIconOnly: PropTypes.bool,
+
+  /** Space between the dropdown and the button */
+  marginTop: PropTypes.string,
 };
 
 Select.defaultProps = {
@@ -496,4 +505,5 @@ Select.defaultProps = {
   isOpen: null,
   onClose: undefined,
   hasIconOnly: false,
+  marginTop: undefined,
 };

--- a/src/components/Select/__snapshots__/Select.spec.js.snap
+++ b/src/components/Select/__snapshots__/Select.spec.js.snap
@@ -19,8 +19,8 @@ exports[`jest-auto-snapshots > Select Matches snapshot when array prop "items" h
   </ForwardRef>
   <ForwardRef
     hasIconOnly={true}
-    isMenu={true}
     isOpen={true}
+    marginTop="jest-auto-snapshots String Fixture"
     position="top"
   >
     <div
@@ -76,8 +76,8 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "disabl
   </ForwardRef>
   <ForwardRef
     hasIconOnly={true}
-    isMenu={true}
     isOpen={true}
+    marginTop="jest-auto-snapshots String Fixture"
     position="top"
   >
     <div
@@ -132,8 +132,8 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "hasIco
   </ForwardRef>
   <ForwardRef
     hasIconOnly={false}
-    isMenu={true}
     isOpen={true}
+    marginTop="jest-auto-snapshots String Fixture"
     position="top"
   >
     <div
@@ -188,8 +188,8 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "hasSea
   </ForwardRef>
   <ForwardRef
     hasIconOnly={true}
-    isMenu={true}
     isOpen={true}
+    marginTop="jest-auto-snapshots String Fixture"
     position="top"
   >
     <ForwardRef>
@@ -235,8 +235,8 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "isOpen
   </ForwardRef>
   <ForwardRef
     hasIconOnly={true}
-    isMenu={true}
     isOpen={false}
+    marginTop="jest-auto-snapshots String Fixture"
     position="top"
   >
     <div
@@ -283,8 +283,8 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "isSpli
 >
   <ForwardRef
     hasIconOnly={true}
-    isMenu={true}
     isOpen={true}
+    marginTop="jest-auto-snapshots String Fixture"
     position="top"
   >
     <div
@@ -339,8 +339,8 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "multiS
   </ForwardRef>
   <ForwardRef
     hasIconOnly={true}
-    isMenu={true}
     isOpen={true}
+    marginTop="jest-auto-snapshots String Fixture"
     position="top"
   >
     <div
@@ -395,8 +395,8 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "shortc
   </ForwardRef>
   <ForwardRef
     hasIconOnly={true}
-    isMenu={true}
     isOpen={true}
+    marginTop="jest-auto-snapshots String Fixture"
     position="top"
   >
     <div
@@ -451,8 +451,8 @@ exports[`jest-auto-snapshots > Select Matches snapshot when passed all props 1`]
   </ForwardRef>
   <ForwardRef
     hasIconOnly={true}
-    isMenu={true}
     isOpen={true}
+    marginTop="jest-auto-snapshots String Fixture"
     position="top"
   >
     <div
@@ -518,7 +518,6 @@ exports[`jest-auto-snapshots > Select Matches snapshot when passed only required
   />
   <ForwardRef
     hasIconOnly={false}
-    isMenu={false}
     isOpen={null}
     position="bottom"
   >

--- a/src/components/Select/style.js
+++ b/src/components/Select/style.js
@@ -28,11 +28,13 @@ export const SelectStyled = styled.div`
   background-color: #ffffff;
   bottom: ${props => (props.position === 'top' ? '100%' : 'initial')};
   top: ${props =>
-    props.position === 'bottom' || props.position === 'right' ? '100%' : 'initial'};
+    props.position === 'bottom' || props.position === 'right'
+      ? '100%'
+      : 'initial'};
   margin-bottom: ${props => (props.position === 'top' ? '8px' : '0')};
   margin-top: ${props =>
-    props.isMenu
-      ? '32px'
+    props.marginTop
+      ? props.marginTop
       : props.position === 'bottom' || props.position === 'right'
       ? '8px'
       : '0'};

--- a/src/documentation/examples/Select/SelectWithMenu.jsx
+++ b/src/documentation/examples/Select/SelectWithMenu.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Select from '@bufferapp/ui/Select';
 import { Person, People, Gear, ArrowLeft } from '@bufferapp/ui/Icon';
-import {NavBarMenu} from '@bufferapp/ui/NavBar';
+import { NavBarMenu } from '@bufferapp/ui/NavBar';
 
 /** With Custom Component */
 export default function ExampleSelectMenu() {
@@ -43,6 +43,7 @@ export default function ExampleSelectMenu() {
           onItemClick: () => console.info('Logout Clicked'),
         },
       ]}
+      marginTop="32px"
     />
   );
 }


### PR DESCRIPTION
Adds a `marginTop` prop so users can add in a custom margin when they use custom buttons for Selects

I was thinking that this is a needed flexibility so we can use any kinds of buttons. Right now I'm using a customButton for the filter Select in the Reply inbox and I need a smaller margin 😊Happy to hear your thoughts !