### PR TITLE
Ensure SelectItem has correct font-family

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6008,7 +6008,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6029,12 +6030,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6049,17 +6052,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6176,7 +6182,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6188,6 +6195,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6202,6 +6210,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6209,12 +6218,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -6233,6 +6244,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6313,7 +6325,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6325,6 +6338,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6410,7 +6424,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6446,6 +6461,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6465,6 +6481,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6508,12 +6525,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/components/Select/SelectItem/style.js
+++ b/src/components/Select/SelectItem/style.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-nested-ternary */
 import styled from 'styled-components';
 import { grayDarker, gray, grayLight } from '../../style/colors';
-import { fontWeightMedium, fontSize } from '../../style/fonts';
+import { fontFamily, fontWeightMedium, fontSize } from '../../style/fonts';
 
 export const SelectItemStyled = styled.li`
   min-height: 32px;
@@ -10,6 +10,7 @@ export const SelectItemStyled = styled.li`
   cursor: pointer;
   display: flex;
   font-size: ${fontSize};
+  font-family: ${fontFamily};
   overflow: hidden;
   text-overflow: ellipsis;
   user-select: none;


### PR DESCRIPTION
To ensure `SelectItem` elements display their labels with the correct font-family value:


![https://d2rsw2kbemic8w.cloudfront.net/items/0j0r2Q2T261v0z1E3L2g/Image%202019-03-13%20at%206.14.19%20PM.png?X-CloudApp-Visitor-Id=2f30e78e31ac8468367e22748068e7b5&v=14c0b35e](https://d2rsw2kbemic8w.cloudfront.net/items/0j0r2Q2T261v0z1E3L2g/Image%202019-03-13%20at%206.14.19%20PM.png?X-CloudApp-Visitor-Id=2f30e78e31ac8468367e22748068e7b5&v=14c0b35e)