### PR TITLE
rollback styled components to v.3.4.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -138,6 +138,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz",
       "integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.0.0"
       }
@@ -236,6 +237,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
       "integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.0.0"
       }
@@ -1021,6 +1023,7 @@
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.1.6.tgz",
       "integrity": "sha512-DMiUzlY9DSjVsOylJssxLHSgj6tWM9PRFJOGW/RaOglVOK9nzTxoOMfTfRQXGUCUQ/HmlG2efwC+XqUEJ5ay4w==",
+      "dev": true,
       "requires": {
         "esutils": "^2.0.2",
         "lodash": "^4.17.10",
@@ -1110,24 +1113,6 @@
       "resolved": "https://registry.npmjs.org/@csstools/convert-colors/-/convert-colors-1.4.0.tgz",
       "integrity": "sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==",
       "dev": true
-    },
-    "@emotion/is-prop-valid": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.6.8.tgz",
-      "integrity": "sha512-IMSL7ekYhmFlILXcouA6ket3vV7u9BqStlXzbKOF9HBtpUPMMlHU+bBxrLOa2NvleVwNIxeq/zL8LafLbeUXcA==",
-      "requires": {
-        "@emotion/memoize": "^0.6.6"
-      }
-    },
-    "@emotion/memoize": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.6.6.tgz",
-      "integrity": "sha512-h4t4jFjtm1YV7UirAFuSuFGyLa+NNxjdkq6DpFLANNQY5rHueFZHVY+8Cu1HYVP6DrheB0kv4m5xPjo7eKT7yQ=="
-    },
-    "@emotion/unitless": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.3.tgz",
-      "integrity": "sha512-4zAPlpDEh2VwXswwr/t8xGNDGg8RQiPxtxZ3qQEXyQsBV39ptTdESCjuBvGze1nLMVrxmTIKmnO/nAV8Tqjjzg=="
     },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
@@ -2201,6 +2186,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-1.10.0.tgz",
       "integrity": "sha512-sQVKG8irFXx14ZfaK1bBePirfkacl3j8nZwSZK+ZjsbnadRHKQTbhXbe/RB1vT6Vgkz45E+V95LBq4KqdhZUNw==",
+      "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.0.0",
         "@babel/helper-module-imports": "^7.0.0",
@@ -2211,7 +2197,8 @@
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
       "resolved": "http://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
+      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
+      "dev": true
     },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
@@ -2595,8 +2582,7 @@
     "base64-js": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
-      "dev": true
+      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
     },
     "batch": {
       "version": "0.6.1",
@@ -5120,7 +5106,8 @@
     "esutils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
     },
     "etag": {
       "version": "1.8.1",
@@ -6008,7 +5995,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6029,12 +6017,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6049,17 +6039,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6176,7 +6169,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6188,6 +6182,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6202,6 +6197,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6209,12 +6205,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -6233,6 +6231,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6313,7 +6312,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6325,6 +6325,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6410,7 +6411,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6446,6 +6448,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6465,6 +6468,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6508,12 +6512,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -6843,7 +6849,8 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
     },
     "has-symbols": {
       "version": "1.0.0",
@@ -6965,8 +6972,7 @@
     "hoist-non-react-statics": {
       "version": "2.5.5",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-      "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==",
-      "dev": true
+      "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
     },
     "home-or-tmp": {
       "version": "2.0.0",
@@ -7428,8 +7434,7 @@
     "ieee754": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
-      "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==",
-      "dev": true
+      "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA=="
     },
     "iferr": {
       "version": "0.1.5",
@@ -9080,7 +9085,8 @@
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "dev": true
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
@@ -9321,11 +9327,6 @@
       "requires": {
         "mimic-fn": "^1.0.0"
       }
-    },
-    "memoize-one": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-4.0.3.tgz",
-      "integrity": "sha512-QmpUu4KqDmX0plH4u+tf0riMc1KHE1+lw95cMrLlXQAFOx/xnBtwhZ52XJxd9X2O6kwKBqX32kmhbhlobD0cuw=="
     },
     "memory-fs": {
       "version": "0.4.1",
@@ -14326,20 +14327,43 @@
       }
     },
     "styled-components": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-4.1.1.tgz",
-      "integrity": "sha512-UzT/qyoOyKpYooeLdwKrPHZ85R8KWl8i0fbyH9I3z6B2WT9uGDCV7J4kbfKsBeSWFD9EytBriEODOkybcUFD/Q==",
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-3.4.10.tgz",
+      "integrity": "sha512-TA8ip8LoILgmSAFd3r326pKtXytUUGu5YWuqZcOQVwVVwB6XqUMn4MHW2IuYJ/HAD81jLrdQed8YWfLSG1LX4Q==",
       "requires": {
-        "@emotion/is-prop-valid": "^0.6.8",
-        "@emotion/unitless": "^0.7.0",
-        "babel-plugin-styled-components": ">= 1",
-        "css-to-react-native": "^2.2.2",
-        "memoize-one": "^4.0.0",
+        "buffer": "^5.0.3",
+        "css-to-react-native": "^2.0.3",
+        "fbjs": "^0.8.16",
+        "hoist-non-react-statics": "^2.5.0",
         "prop-types": "^15.5.4",
-        "react-is": "^16.6.0",
+        "react-is": "^16.3.1",
         "stylis": "^3.5.0",
         "stylis-rule-sheet": "^0.0.10",
-        "supports-color": "^5.5.0"
+        "supports-color": "^3.2.3"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
+          "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
+          }
+        },
+        "has-flag": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+        },
+        "supports-color": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "requires": {
+            "has-flag": "^1.0.0"
+          }
+        }
       }
     },
     "stylehacks": {
@@ -14389,6 +14413,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }
@@ -14734,7 +14759,8 @@
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true
     },
     "to-object-path": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "immutability-helper": "^2.9.0",
     "react": "16.6.3",
     "react-dom": "16.6.3",
-    "styled-components": "4.1.1"
+    "styled-components": "3.4.10"
   },
   "devDependencies": {
     "@babel/cli": "7.1.5",

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+RED='\033[0;31m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+if [ -z $1 ]
+  then
+    echo -e $RED"Sync error:" $NC "plesase provide a destination folder"
+    exit 1
+fi
+
+npm run build:lib &&\
+  # remove spec and test files
+  rm ./lib/*/*.test.* &&\
+  rm ./lib/*/*.spec.* &&\
+  rsync -r ./lib/ $1

--- a/src/components/AppShell/__snapshots__/AppShell.spec.js.snap
+++ b/src/components/AppShell/__snapshots__/AppShell.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`jest-auto-snapshots > AppShell Matches snapshot when passed only required props 1`] = `
-<ForwardRef>
+<styled.div>
   <NavBar
     user={
       Object {
@@ -20,13 +20,13 @@ exports[`jest-auto-snapshots > AppShell Matches snapshot when passed only requir
       }
     }
   />
-  <ForwardRef>
-    <ForwardRef>
+  <styled.div>
+    <styled.div>
       <NodeFixture />
-    </ForwardRef>
-    <ForwardRef>
+    </styled.div>
+    <styled.div>
       <NodeFixture />
-    </ForwardRef>
-  </ForwardRef>
-</ForwardRef>
+    </styled.div>
+  </styled.div>
+</styled.div>
 `;

--- a/src/components/Avatar/__snapshots__/Avatar.spec.js.snap
+++ b/src/components/Avatar/__snapshots__/Avatar.spec.js.snap
@@ -1,46 +1,46 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`jest-auto-snapshots > Avatar Matches snapshot when boolean prop "isOnline" is set to: "false" 1`] = `
-<ForwardRef
+<styled.div
   size="large"
 >
   <Unknown
     size="large"
   />
-  <ForwardRef
+  <styled.img
     alt="jest-auto-snapshots String Fixture"
     size="large"
     src="jest-auto-snapshots String Fixture"
     type="default"
   />
-</ForwardRef>
+</styled.div>
 `;
 
 exports[`jest-auto-snapshots > Avatar Matches snapshot when passed all props 1`] = `
-<ForwardRef
+<styled.div
   size="large"
 >
   <Unknown
     size="large"
   />
-  <ForwardRef
+  <styled.img
     alt="jest-auto-snapshots String Fixture"
     size="large"
     src="jest-auto-snapshots String Fixture"
     type="default"
   />
-</ForwardRef>
+</styled.div>
 `;
 
 exports[`jest-auto-snapshots > Avatar Matches snapshot when passed only required props 1`] = `
-<ForwardRef
+<styled.div
   size="small"
 >
-  <ForwardRef
+  <styled.img
     alt="jest-auto-snapshots String Fixture"
     size="small"
     src="jest-auto-snapshots String Fixture"
     type="default"
   />
-</ForwardRef>
+</styled.div>
 `;

--- a/src/components/Button/Button.jsx
+++ b/src/components/Button/Button.jsx
@@ -58,7 +58,7 @@ const Button = ({
     hasIconOnly={hasIconOnly}
     fullWidth={fullWidth}
     data-tip={tooltip}
-    ref={innerRef}
+    innerRef={innerRef}
   >
     {icon}
     {hasIconOnly && <VisuallyHiddenLabel>{label}</VisuallyHiddenLabel>}

--- a/src/components/Button/__snapshots__/Button.spec.js.snap
+++ b/src/components/Button/__snapshots__/Button.spec.js.snap
@@ -1,204 +1,213 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`jest-auto-snapshots > Button Matches snapshot when array prop "items" has one item: "[object Object]" 1`] = `
-<ForwardRef
+<styled.button
   data-tip="jest-auto-snapshots String Fixture"
   disabled={true}
   fullWidth={true}
   hasIconOnly={true}
   icon={<NodeFixture />}
+  innerRef={<NodeFixture />}
   isSplit={true}
   size="small"
   type="link"
 >
   <NodeFixture />
-  <ForwardRef>
+  <styled.span>
     jest-auto-snapshots String Fixture
-  </ForwardRef>
-  <ForwardRef
+  </styled.span>
+  <styled.img
     alt="loading"
     src="./images/loading-gray.svg"
   />
-</ForwardRef>
+</styled.button>
 `;
 
 exports[`jest-auto-snapshots > Button Matches snapshot when array prop "items" is an empty array: "[]" 1`] = `
-<ForwardRef
+<styled.button
   data-tip="jest-auto-snapshots String Fixture"
   disabled={true}
   fullWidth={true}
   hasIconOnly={true}
   icon={<NodeFixture />}
+  innerRef={<NodeFixture />}
   isSplit={true}
   size="small"
   type="link"
 >
   <NodeFixture />
-  <ForwardRef>
+  <styled.span>
     jest-auto-snapshots String Fixture
-  </ForwardRef>
-  <ForwardRef
+  </styled.span>
+  <styled.img
     alt="loading"
     src="./images/loading-gray.svg"
   />
-</ForwardRef>
+</styled.button>
 `;
 
 exports[`jest-auto-snapshots > Button Matches snapshot when boolean prop "disabled" is set to: "false" 1`] = `
-<ForwardRef
+<styled.button
   data-tip="jest-auto-snapshots String Fixture"
   disabled={false}
   fullWidth={true}
   hasIconOnly={true}
   icon={<NodeFixture />}
+  innerRef={<NodeFixture />}
   isSplit={true}
   onClick={[MockFunction]}
   size="small"
   type="link"
 >
   <NodeFixture />
-  <ForwardRef>
+  <styled.span>
     jest-auto-snapshots String Fixture
-  </ForwardRef>
-  <ForwardRef
+  </styled.span>
+  <styled.img
     alt="loading"
     src="./images/loading-gray.svg"
   />
-</ForwardRef>
+</styled.button>
 `;
 
 exports[`jest-auto-snapshots > Button Matches snapshot when boolean prop "fullWidth" is set to: "false" 1`] = `
-<ForwardRef
+<styled.button
   data-tip="jest-auto-snapshots String Fixture"
   disabled={true}
   fullWidth={false}
   hasIconOnly={true}
   icon={<NodeFixture />}
+  innerRef={<NodeFixture />}
   isSplit={true}
   size="small"
   type="link"
 >
   <NodeFixture />
-  <ForwardRef>
+  <styled.span>
     jest-auto-snapshots String Fixture
-  </ForwardRef>
-  <ForwardRef
+  </styled.span>
+  <styled.img
     alt="loading"
     src="./images/loading-gray.svg"
   />
-</ForwardRef>
+</styled.button>
 `;
 
 exports[`jest-auto-snapshots > Button Matches snapshot when boolean prop "hasIconOnly" is set to: "false" 1`] = `
-<ForwardRef
+<styled.button
   data-tip="jest-auto-snapshots String Fixture"
   disabled={true}
   fullWidth={true}
   hasIconOnly={false}
   icon={<NodeFixture />}
+  innerRef={<NodeFixture />}
   isSplit={true}
   size="small"
   type="link"
 >
   <NodeFixture />
-  <ForwardRef
+  <styled.div
     hasIcon={true}
   >
     jest-auto-snapshots String Fixture
-  </ForwardRef>
-  <ForwardRef
+  </styled.div>
+  <styled.img
     alt="loading"
     src="./images/loading-gray.svg"
   />
-</ForwardRef>
+</styled.button>
 `;
 
 exports[`jest-auto-snapshots > Button Matches snapshot when boolean prop "isSelect" is set to: "false" 1`] = `
-<ForwardRef
+<styled.button
   data-tip="jest-auto-snapshots String Fixture"
   disabled={true}
   fullWidth={true}
   hasIconOnly={true}
   icon={<NodeFixture />}
+  innerRef={<NodeFixture />}
   isSplit={true}
   size="small"
   type="link"
 >
   <NodeFixture />
-  <ForwardRef>
+  <styled.span>
     jest-auto-snapshots String Fixture
-  </ForwardRef>
-  <ForwardRef
+  </styled.span>
+  <styled.img
     alt="loading"
     src="./images/loading-gray.svg"
   />
-</ForwardRef>
+</styled.button>
 `;
 
 exports[`jest-auto-snapshots > Button Matches snapshot when boolean prop "isSplit" is set to: "false" 1`] = `
-<ForwardRef
+<styled.button
   data-tip="jest-auto-snapshots String Fixture"
   disabled={true}
   fullWidth={true}
   hasIconOnly={true}
   icon={<NodeFixture />}
+  innerRef={<NodeFixture />}
   isSplit={false}
   size="small"
   type="link"
 >
   <NodeFixture />
-  <ForwardRef>
+  <styled.span>
     jest-auto-snapshots String Fixture
-  </ForwardRef>
-  <ForwardRef
+  </styled.span>
+  <styled.img
     alt="loading"
     src="./images/loading-gray.svg"
   />
-</ForwardRef>
+</styled.button>
 `;
 
 exports[`jest-auto-snapshots > Button Matches snapshot when boolean prop "loading" is set to: "false" 1`] = `
-<ForwardRef
+<styled.button
   data-tip="jest-auto-snapshots String Fixture"
   disabled={true}
   fullWidth={true}
   hasIconOnly={true}
   icon={<NodeFixture />}
+  innerRef={<NodeFixture />}
   isSplit={true}
   size="small"
   type="link"
 >
   <NodeFixture />
-  <ForwardRef>
+  <styled.span>
     jest-auto-snapshots String Fixture
-  </ForwardRef>
-</ForwardRef>
+  </styled.span>
+</styled.button>
 `;
 
 exports[`jest-auto-snapshots > Button Matches snapshot when passed all props 1`] = `
-<ForwardRef
+<styled.button
   data-tip="jest-auto-snapshots String Fixture"
   disabled={true}
   fullWidth={true}
   hasIconOnly={true}
   icon={<NodeFixture />}
+  innerRef={<NodeFixture />}
   isSplit={true}
   size="small"
   type="link"
 >
   <NodeFixture />
-  <ForwardRef>
+  <styled.span>
     jest-auto-snapshots String Fixture
-  </ForwardRef>
-  <ForwardRef
+  </styled.span>
+  <styled.img
     alt="loading"
     src="./images/loading-gray.svg"
   />
-</ForwardRef>
+</styled.button>
 `;
 
 exports[`jest-auto-snapshots > Button Matches snapshot when passed only required props 1`] = `
-<ForwardRef
+<styled.button
   disabled={false}
   fullWidth={false}
   hasIconOnly={false}
@@ -206,8 +215,8 @@ exports[`jest-auto-snapshots > Button Matches snapshot when passed only required
   size="medium"
   type="secondary"
 >
-  <ForwardRef
+  <styled.div
     hasIcon={false}
   />
-</ForwardRef>
+</styled.button>
 `;

--- a/src/components/Input/__snapshots__/Input.spec.js.snap
+++ b/src/components/Input/__snapshots__/Input.spec.js.snap
@@ -10,7 +10,7 @@ exports[`jest-auto-snapshots > Input Matches snapshot when boolean prop "disable
   >
     jest-auto-snapshots String Fixture
   </Text>
-  <ForwardRef
+  <styled.input
     disabled={false}
     hasError={true}
     name="jest-auto-snapshots String Fixture"
@@ -44,7 +44,7 @@ exports[`jest-auto-snapshots > Input Matches snapshot when boolean prop "hasErro
   >
     jest-auto-snapshots String Fixture
   </Text>
-  <ForwardRef
+  <styled.input
     disabled={true}
     hasError={false}
     name="jest-auto-snapshots String Fixture"
@@ -75,7 +75,7 @@ exports[`jest-auto-snapshots > Input Matches snapshot when passed all props 1`] 
   >
     jest-auto-snapshots String Fixture
   </Text>
-  <ForwardRef
+  <styled.input
     disabled={true}
     hasError={true}
     name="jest-auto-snapshots String Fixture"
@@ -101,7 +101,7 @@ exports[`jest-auto-snapshots > Input Matches snapshot when passed all props 1`] 
 
 exports[`jest-auto-snapshots > Input Matches snapshot when passed only required props 1`] = `
 <div>
-  <ForwardRef
+  <styled.input
     disabled={false}
     hasError={false}
     name="jest-auto-snapshots String Fixture"

--- a/src/components/NavBar/NavBarMenu/__snapshots__/NavBarMenu.spec.js.snap
+++ b/src/components/NavBar/NavBarMenu/__snapshots__/NavBarMenu.spec.js.snap
@@ -1,25 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`jest-auto-snapshots > NavBarMenu Matches snapshot when passed only required props 1`] = `
-<ForwardRef>
-  <ForwardRef>
-    <ForwardRef>
+<styled.div>
+  <styled.div>
+    <styled.div>
       jest-auto-snapshots String Fixture
-    </ForwardRef>
-    <ForwardRef>
+    </styled.div>
+    <styled.div>
       jest-auto-snapshots String Fixture
-    </ForwardRef>
-  </ForwardRef>
-  <ForwardRef
+    </styled.div>
+  </styled.div>
+  <styled.div
     onClick={[MockFunction]}
   />
-  <ForwardRef
+  <styled.div
     onClick={[MockFunction]}
   >
     <ChevronDownIcon
       color="grayLight"
       size="large"
     />
-  </ForwardRef>
-</ForwardRef>
+  </styled.div>
+</styled.div>
 `;

--- a/src/components/NavBar/__snapshots__/NavBar.spec.js.snap
+++ b/src/components/NavBar/__snapshots__/NavBar.spec.js.snap
@@ -1,14 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`jest-auto-snapshots > NavBar Matches snapshot when passed only required props 1`] = `
-<ForwardRef>
-  <ForwardRef>
+<styled.nav>
+  <styled.div>
     <BufferLogo />
     <NavBarProduct
       activeProduct="publish"
     />
-  </ForwardRef>
-  <ForwardRef>
+  </styled.div>
+  <styled.div>
     <Select
       customButton={[Function]}
       hasIconOnly={false}
@@ -34,6 +34,6 @@ exports[`jest-auto-snapshots > NavBar Matches snapshot when passed only required
       size="medium"
       type="secondary"
     />
-  </ForwardRef>
-</ForwardRef>
+  </styled.div>
+</styled.nav>
 `;

--- a/src/components/Search/Search.jsx
+++ b/src/components/Search/Search.jsx
@@ -39,7 +39,7 @@ export default class Search extends React.Component {
           placeholder={placeholder}
           type="text"
           value={search}
-          ref={inputRef => this.inputRef = inputRef}
+          innerRef={inputRef => this.inputRef = inputRef}
           onChange={event => this.onChange(event)}
         />
       </SearchWrapper>

--- a/src/components/Search/__snapshots__/Search.spec.js.snap
+++ b/src/components/Search/__snapshots__/Search.spec.js.snap
@@ -1,34 +1,37 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`jest-auto-snapshots > Search Matches snapshot when boolean prop "isOpen" is set to: "false" 1`] = `
-<ForwardRef>
-  <ForwardRef
+<styled.div>
+  <styled.input
+    innerRef={[Function]}
     onChange={[Function]}
     placeholder="jest-auto-snapshots String Fixture"
     type="text"
     value=""
   />
-</ForwardRef>
+</styled.div>
 `;
 
 exports[`jest-auto-snapshots > Search Matches snapshot when passed all props 1`] = `
-<ForwardRef>
-  <ForwardRef
+<styled.div>
+  <styled.input
+    innerRef={[Function]}
     onChange={[Function]}
     placeholder="jest-auto-snapshots String Fixture"
     type="text"
     value=""
   />
-</ForwardRef>
+</styled.div>
 `;
 
 exports[`jest-auto-snapshots > Search Matches snapshot when passed only required props 1`] = `
-<ForwardRef>
-  <ForwardRef
+<styled.div>
+  <styled.input
+    innerRef={[Function]}
     onChange={[Function]}
     placeholder=""
     type="text"
     value=""
   />
-</ForwardRef>
+</styled.div>
 `;

--- a/src/components/Select/Select.jsx
+++ b/src/components/Select/Select.jsx
@@ -97,7 +97,8 @@ export default class Select extends React.Component {
 
   // Close the popover
   closePopover = e => {
-    if (this.searchInputNode && this.searchInputNode.contains(e.target)) return;
+    if (this.searchInputNode &&
+      this.searchInputNode.contains(e.target)) return;
     const { isOpen } = this.state;
 
     if (isOpen) {
@@ -342,7 +343,7 @@ export default class Select extends React.Component {
           type={type}
           disabled={disabled}
           onClick={!disabled ? this.onButtonClick : undefined}
-          ref={activeButton => this.activeButton = activeButton}
+          innerRef={activeButton => this.activeButton = activeButton}
         >
           <ChevronDown
             color={type === 'primary' && !disabled ? 'white' : 'grayDark'}
@@ -403,7 +404,7 @@ export default class Select extends React.Component {
         {hasSearch && (
           <SearchBarWrapper
             id="searchInput"
-            ref={node => (this.searchInputNode = node)}
+            innerRef={node => (this.searchInputNode = node)}
           >
             <SearchIcon />
             <Search
@@ -413,7 +414,7 @@ export default class Select extends React.Component {
             />
           </SearchBarWrapper>
         )}
-        <SelectItems ref={itemsNode => (this.itemsNode = itemsNode)}>
+        <SelectItems innerRef={itemsNode => (this.itemsNode = itemsNode)}>
           {items.map((item, idx) => [
             item.hasDivider && (
               <SelectItemDivider key={`${this.getItemId(item)}--divider`} />
@@ -445,7 +446,7 @@ export default class Select extends React.Component {
         onKeyUp={this.onClick}
         tabIndex={0}
         isSplit={isSplit}
-        ref={selectNode => (this.selectNode = selectNode)}
+        innerRef={selectNode => (this.selectNode = selectNode)}
         data-tip={disabled ? '' : tooltip}
       >
         {this.renderSelectButton()}

--- a/src/components/Select/__snapshots__/Select.spec.js.snap
+++ b/src/components/Select/__snapshots__/Select.spec.js.snap
@@ -1,30 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`jest-auto-snapshots > Select Matches snapshot when array prop "items" has one item: "[object Object]" 1`] = `
-<ForwardRef
+<styled.div
   data-tip=""
+  innerRef={[Function]}
   isSplit={true}
   onClick={[Function]}
   onKeyUp={[Function]}
   role="button"
   tabIndex={0}
 >
-  <ForwardRef
+  <styled.div
     disabled={true}
+    innerRef={[Function]}
     type="primary"
   >
     <ChevronDownIcon
       color="grayDark"
     />
-  </ForwardRef>
-  <ForwardRef
+  </styled.div>
+  <styled.div
     hasIconOnly={true}
     isOpen={true}
     marginTop="jest-auto-snapshots String Fixture"
     position="top"
   >
-    <ForwardRef
+    <styled.div
       id="searchInput"
+      innerRef={[Function]}
     >
       <SearchIcon />
       <Search
@@ -32,8 +35,10 @@ exports[`jest-auto-snapshots > Select Matches snapshot when array prop "items" h
         onChange={[Function]}
         placeholder="jest-auto-snapshots String Fixture"
       />
-    </ForwardRef>
-    <ForwardRef>
+    </styled.div>
+    <styled.ul
+      innerRef={[Function]}
+    >
       <SelectItem
         getItemId={[Function]}
         hasSearch={true}
@@ -54,37 +59,40 @@ exports[`jest-auto-snapshots > Select Matches snapshot when array prop "items" h
         multiSelect={true}
         onClick={[Function]}
       />
-    </ForwardRef>
-  </ForwardRef>
-</ForwardRef>
+    </styled.ul>
+  </styled.div>
+</styled.div>
 `;
 
 exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "disabled" is set to: "false" 1`] = `
-<ForwardRef
+<styled.div
   data-tip="jest-auto-snapshots String Fixture"
+  innerRef={[Function]}
   isSplit={true}
   onClick={[Function]}
   onKeyUp={[Function]}
   role="button"
   tabIndex={0}
 >
-  <ForwardRef
+  <styled.div
     disabled={false}
+    innerRef={[Function]}
     onClick={[Function]}
     type="primary"
   >
     <ChevronDownIcon
       color="white"
     />
-  </ForwardRef>
-  <ForwardRef
+  </styled.div>
+  <styled.div
     hasIconOnly={true}
     isOpen={true}
     marginTop="jest-auto-snapshots String Fixture"
     position="top"
   >
-    <ForwardRef
+    <styled.div
       id="searchInput"
+      innerRef={[Function]}
     >
       <SearchIcon />
       <Search
@@ -92,8 +100,10 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "disabl
         onChange={[Function]}
         placeholder="jest-auto-snapshots String Fixture"
       />
-    </ForwardRef>
-    <ForwardRef>
+    </styled.div>
+    <styled.ul
+      innerRef={[Function]}
+    >
       <SelectItem
         getItemId={[Function]}
         hasSearch={true}
@@ -114,36 +124,39 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "disabl
         multiSelect={true}
         onClick={[Function]}
       />
-    </ForwardRef>
-  </ForwardRef>
-</ForwardRef>
+    </styled.ul>
+  </styled.div>
+</styled.div>
 `;
 
 exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "hasIconOnly" is set to: "false" 1`] = `
-<ForwardRef
+<styled.div
   data-tip=""
+  innerRef={[Function]}
   isSplit={true}
   onClick={[Function]}
   onKeyUp={[Function]}
   role="button"
   tabIndex={0}
 >
-  <ForwardRef
+  <styled.div
     disabled={true}
+    innerRef={[Function]}
     type="primary"
   >
     <ChevronDownIcon
       color="grayDark"
     />
-  </ForwardRef>
-  <ForwardRef
+  </styled.div>
+  <styled.div
     hasIconOnly={false}
     isOpen={true}
     marginTop="jest-auto-snapshots String Fixture"
     position="top"
   >
-    <ForwardRef
+    <styled.div
       id="searchInput"
+      innerRef={[Function]}
     >
       <SearchIcon />
       <Search
@@ -151,8 +164,10 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "hasIco
         onChange={[Function]}
         placeholder="jest-auto-snapshots String Fixture"
       />
-    </ForwardRef>
-    <ForwardRef>
+    </styled.div>
+    <styled.ul
+      innerRef={[Function]}
+    >
       <SelectItem
         getItemId={[Function]}
         hasSearch={true}
@@ -173,35 +188,39 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "hasIco
         multiSelect={true}
         onClick={[Function]}
       />
-    </ForwardRef>
-  </ForwardRef>
-</ForwardRef>
+    </styled.ul>
+  </styled.div>
+</styled.div>
 `;
 
 exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "hasSearch" is set to: "false" 1`] = `
-<ForwardRef
+<styled.div
   data-tip=""
+  innerRef={[Function]}
   isSplit={true}
   onClick={[Function]}
   onKeyUp={[Function]}
   role="button"
   tabIndex={0}
 >
-  <ForwardRef
+  <styled.div
     disabled={true}
+    innerRef={[Function]}
     type="primary"
   >
     <ChevronDownIcon
       color="grayDark"
     />
-  </ForwardRef>
-  <ForwardRef
+  </styled.div>
+  <styled.div
     hasIconOnly={true}
     isOpen={true}
     marginTop="jest-auto-snapshots String Fixture"
     position="top"
   >
-    <ForwardRef>
+    <styled.ul
+      innerRef={[Function]}
+    >
       <SelectItem
         getItemId={[Function]}
         hasSearch={false}
@@ -222,36 +241,39 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "hasSea
         multiSelect={true}
         onClick={[Function]}
       />
-    </ForwardRef>
-  </ForwardRef>
-</ForwardRef>
+    </styled.ul>
+  </styled.div>
+</styled.div>
 `;
 
 exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "isOpen" is set to: "false" 1`] = `
-<ForwardRef
+<styled.div
   data-tip=""
+  innerRef={[Function]}
   isSplit={true}
   onClick={[Function]}
   onKeyUp={[Function]}
   role="button"
   tabIndex={0}
 >
-  <ForwardRef
+  <styled.div
     disabled={true}
+    innerRef={[Function]}
     type="primary"
   >
     <ChevronDownIcon
       color="grayDark"
     />
-  </ForwardRef>
-  <ForwardRef
+  </styled.div>
+  <styled.div
     hasIconOnly={true}
     isOpen={false}
     marginTop="jest-auto-snapshots String Fixture"
     position="top"
   >
-    <ForwardRef
+    <styled.div
       id="searchInput"
+      innerRef={[Function]}
     >
       <SearchIcon />
       <Search
@@ -259,8 +281,10 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "isOpen
         onChange={[Function]}
         placeholder="jest-auto-snapshots String Fixture"
       />
-    </ForwardRef>
-    <ForwardRef>
+    </styled.div>
+    <styled.ul
+      innerRef={[Function]}
+    >
       <SelectItem
         getItemId={[Function]}
         hasSearch={true}
@@ -281,28 +305,30 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "isOpen
         multiSelect={true}
         onClick={[Function]}
       />
-    </ForwardRef>
-  </ForwardRef>
-</ForwardRef>
+    </styled.ul>
+  </styled.div>
+</styled.div>
 `;
 
 exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "isSplit" is set to: "false" 1`] = `
-<ForwardRef
+<styled.div
   data-tip=""
+  innerRef={[Function]}
   isSplit={false}
   onClick={[Function]}
   onKeyUp={[Function]}
   role="button"
   tabIndex={0}
 >
-  <ForwardRef
+  <styled.div
     hasIconOnly={true}
     isOpen={true}
     marginTop="jest-auto-snapshots String Fixture"
     position="top"
   >
-    <ForwardRef
+    <styled.div
       id="searchInput"
+      innerRef={[Function]}
     >
       <SearchIcon />
       <Search
@@ -310,8 +336,10 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "isSpli
         onChange={[Function]}
         placeholder="jest-auto-snapshots String Fixture"
       />
-    </ForwardRef>
-    <ForwardRef>
+    </styled.div>
+    <styled.ul
+      innerRef={[Function]}
+    >
       <SelectItem
         getItemId={[Function]}
         hasSearch={true}
@@ -332,36 +360,39 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "isSpli
         multiSelect={true}
         onClick={[Function]}
       />
-    </ForwardRef>
-  </ForwardRef>
-</ForwardRef>
+    </styled.ul>
+  </styled.div>
+</styled.div>
 `;
 
 exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "multiSelect" is set to: "false" 1`] = `
-<ForwardRef
+<styled.div
   data-tip=""
+  innerRef={[Function]}
   isSplit={true}
   onClick={[Function]}
   onKeyUp={[Function]}
   role="button"
   tabIndex={0}
 >
-  <ForwardRef
+  <styled.div
     disabled={true}
+    innerRef={[Function]}
     type="primary"
   >
     <ChevronDownIcon
       color="grayDark"
     />
-  </ForwardRef>
-  <ForwardRef
+  </styled.div>
+  <styled.div
     hasIconOnly={true}
     isOpen={true}
     marginTop="jest-auto-snapshots String Fixture"
     position="top"
   >
-    <ForwardRef
+    <styled.div
       id="searchInput"
+      innerRef={[Function]}
     >
       <SearchIcon />
       <Search
@@ -369,8 +400,10 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "multiS
         onChange={[Function]}
         placeholder="jest-auto-snapshots String Fixture"
       />
-    </ForwardRef>
-    <ForwardRef>
+    </styled.div>
+    <styled.ul
+      innerRef={[Function]}
+    >
       <SelectItem
         getItemId={[Function]}
         hasSearch={true}
@@ -391,36 +424,39 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "multiS
         multiSelect={false}
         onClick={[Function]}
       />
-    </ForwardRef>
-  </ForwardRef>
-</ForwardRef>
+    </styled.ul>
+  </styled.div>
+</styled.div>
 `;
 
 exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "shortcutsEnabled" is set to: "false" 1`] = `
-<ForwardRef
+<styled.div
   data-tip=""
+  innerRef={[Function]}
   isSplit={true}
   onClick={[Function]}
   onKeyUp={[Function]}
   role="button"
   tabIndex={0}
 >
-  <ForwardRef
+  <styled.div
     disabled={true}
+    innerRef={[Function]}
     type="primary"
   >
     <ChevronDownIcon
       color="grayDark"
     />
-  </ForwardRef>
-  <ForwardRef
+  </styled.div>
+  <styled.div
     hasIconOnly={true}
     isOpen={true}
     marginTop="jest-auto-snapshots String Fixture"
     position="top"
   >
-    <ForwardRef
+    <styled.div
       id="searchInput"
+      innerRef={[Function]}
     >
       <SearchIcon />
       <Search
@@ -428,8 +464,10 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "shortc
         onChange={[Function]}
         placeholder="jest-auto-snapshots String Fixture"
       />
-    </ForwardRef>
-    <ForwardRef>
+    </styled.div>
+    <styled.ul
+      innerRef={[Function]}
+    >
       <SelectItem
         getItemId={[Function]}
         hasSearch={true}
@@ -450,36 +488,39 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "shortc
         multiSelect={true}
         onClick={[Function]}
       />
-    </ForwardRef>
-  </ForwardRef>
-</ForwardRef>
+    </styled.ul>
+  </styled.div>
+</styled.div>
 `;
 
 exports[`jest-auto-snapshots > Select Matches snapshot when passed all props 1`] = `
-<ForwardRef
+<styled.div
   data-tip=""
+  innerRef={[Function]}
   isSplit={true}
   onClick={[Function]}
   onKeyUp={[Function]}
   role="button"
   tabIndex={0}
 >
-  <ForwardRef
+  <styled.div
     disabled={true}
+    innerRef={[Function]}
     type="primary"
   >
     <ChevronDownIcon
       color="grayDark"
     />
-  </ForwardRef>
-  <ForwardRef
+  </styled.div>
+  <styled.div
     hasIconOnly={true}
     isOpen={true}
     marginTop="jest-auto-snapshots String Fixture"
     position="top"
   >
-    <ForwardRef
+    <styled.div
       id="searchInput"
+      innerRef={[Function]}
     >
       <SearchIcon />
       <Search
@@ -487,8 +528,10 @@ exports[`jest-auto-snapshots > Select Matches snapshot when passed all props 1`]
         onChange={[Function]}
         placeholder="jest-auto-snapshots String Fixture"
       />
-    </ForwardRef>
-    <ForwardRef>
+    </styled.div>
+    <styled.ul
+      innerRef={[Function]}
+    >
       <SelectItem
         getItemId={[Function]}
         hasSearch={true}
@@ -509,13 +552,14 @@ exports[`jest-auto-snapshots > Select Matches snapshot when passed all props 1`]
         multiSelect={true}
         onClick={[Function]}
       />
-    </ForwardRef>
-  </ForwardRef>
-</ForwardRef>
+    </styled.ul>
+  </styled.div>
+</styled.div>
 `;
 
 exports[`jest-auto-snapshots > Select Matches snapshot when passed only required props 1`] = `
-<ForwardRef
+<styled.div
+  innerRef={[Function]}
   isSplit={false}
   onClick={[Function]}
   onKeyUp={[Function]}
@@ -543,12 +587,14 @@ exports[`jest-auto-snapshots > Select Matches snapshot when passed only required
     size="medium"
     type="secondary"
   />
-  <ForwardRef
+  <styled.div
     hasIconOnly={false}
     isOpen={null}
     position="bottom"
   >
-    <ForwardRef>
+    <styled.ul
+      innerRef={[Function]}
+    >
       <SelectItem
         getItemId={[Function]}
         hasSearch={false}
@@ -562,7 +608,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when passed only required
         }
         onClick={[Function]}
       />
-    </ForwardRef>
-  </ForwardRef>
-</ForwardRef>
+    </styled.ul>
+  </styled.div>
+</styled.div>
 `;

--- a/src/components/Text/__snapshots__/Text.spec.js.snap
+++ b/src/components/Text/__snapshots__/Text.spec.js.snap
@@ -1,19 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`jest-auto-snapshots > Text Matches snapshot when boolean prop "hasError" is set to: "false" 1`] = `
-<ForwardRef>
+<styled.span>
   <NodeFixture />
-</ForwardRef>
+</styled.span>
 `;
 
 exports[`jest-auto-snapshots > Text Matches snapshot when boolean prop "light" is set to: "false" 1`] = `
-<ForwardRef>
+<styled.span>
   <NodeFixture />
-</ForwardRef>
+</styled.span>
 `;
 
 exports[`jest-auto-snapshots > Text Matches snapshot when passed all props 1`] = `
-<ForwardRef>
+<styled.span>
   <NodeFixture />
-</ForwardRef>
+</styled.span>
 `;


### PR DESCRIPTION
This is useful because styled components >= 4.0 uses `React.forwardRef`, and that is breaking snapshot testing with Jest and Storybook in Analyze. 

This also includes a sync script I was using to temporary clone the build folder in Analyze, we can probably remove that, if we are merging this in.