### PR TITLE
Change href on product links

### DIFF
--- a/src/components/NavBar/NavBarProducts/NavBarProducts.jsx
+++ b/src/components/NavBar/NavBarProducts/NavBarProducts.jsx
@@ -39,21 +39,21 @@ const NavBarProduct = ({ activeProduct }) => (
   <StlyedNavBarProduct>
     <ProductLink
       active={activeProduct === 'publish'}
-      href={activeProduct !== 'publish' ? 'https://publish.buffer.com' : '/'}
+      href='https://publish.buffer.com'
     >
       <IconPublish />
       <ProductText>Publish</ProductText>
     </ProductLink>
     <ProductLink
       active={activeProduct === 'reply'}
-      href={activeProduct !== 'reply' ? 'https://reply.buffer.com' : '/'}
+      href='https://reply.buffer.com'
     >
       <IconReply />
       <ProductText>Reply</ProductText>
     </ProductLink>
     <ProductLink
       active={activeProduct === 'analyze'}
-      href={activeProduct !== 'analyze' ? 'https://analyze.buffer.com' : '/'}
+      href='https://analyze.buffer.com'
     >
       <IconAnalyze />
       <ProductText>Analyze</ProductText>


### PR DESCRIPTION
This change is needed so users are able to click the product links from the Account app and redirected to the product page.