### PR TITLE
Add defaults to user menu in AppShell

### DIFF
--- a/src/components/NavBar/NavBar.jsx
+++ b/src/components/NavBar/NavBar.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { Info as InfoIcon } from '../Icon';
+import { Info as InfoIcon, ArrowLeft } from '../Icon';
 
 import { grayDarker, gray } from '../style/colors';
 import { fontWeightMedium } from '../style/fonts';
@@ -11,6 +11,10 @@ import BufferLogo from './BufferLogo';
 import NavBarMenu from './NavBarMenu/NavBarMenu';
 import NavBarProducts from './NavBarProducts/NavBarProducts';
 
+export function getLogoutUrl(baseUrl = '') {
+  const [, productPath] = baseUrl.match(/https*:\/\/(.+)\.buffer\.com/);
+  return `https://login${productPath.includes('local') ? '.local' : ''}.buffer.com/logout?redirect=https://${productPath}.buffer.com`;
+}
 
 const NavBarStyled = styled.nav`
   height: 64px;
@@ -74,7 +78,17 @@ const NavBar = ({ activeProduct, user, helpMenuItems }) => (
       <Select
         hideSearch
         customButton={handleClick => (<NavBarMenu user={user} onClick={handleClick} />)}
-        items={user.menuItems}
+        items={[...user.menuItems,
+          {
+              id: 'logout',
+              title: 'Logout',
+              icon: <ArrowLeft color={gray} />,
+              hasDivider: true,
+              onItemClick: () => {
+              window.location.assign(getLogoutUrl());
+            },
+          },
+        ]}
         horizontalOffset="16px"
       />
     </NavBarRight>

--- a/src/components/NavBar/NavBar.jsx
+++ b/src/components/NavBar/NavBar.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { Info as InfoIcon, ArrowLeft } from '../Icon';
+import { Info as InfoIcon, ArrowLeft, Person as PersonIcon } from '../Icon';
 
 import { grayDarker, gray } from '../style/colors';
 import { fontWeightMedium } from '../style/fonts';
@@ -78,7 +78,14 @@ const NavBar = ({ activeProduct, user, helpMenuItems }) => (
       <Select
         hideSearch
         customButton={handleClick => (<NavBarMenu user={user} onClick={handleClick} />)}
-        items={[...user.menuItems,
+        items={[
+          {
+            id: 'Account',
+            title: 'Account',
+            icon: <PersonIcon color={gray} />,
+            onItemClick: () => { window.location.assign(`https://account.buffer.com?product=${activeProduct}&username=${encodeURI(user.name)}`); },
+          },
+          ...user.menuItems,
           {
               id: 'logout',
               title: 'Logout',

--- a/src/components/NavBar/NavBar.spec.js
+++ b/src/components/NavBar/NavBar.spec.js
@@ -1,4 +1,19 @@
 import snap from 'jest-auto-snapshots';
-import NavBar from './NavBar';
+import NavBar, { getLogoutUrl } from './NavBar';
+
+describe('Logout url', () => {
+  it('return logout url', () => {
+    const baseUrl = 'https://analyze.buffer.com/facebook/overview/4e88a092512f7e1556000000';
+    const productPath = 'analyze'
+    expect(getLogoutUrl(baseUrl)).toBe(`https://login${productPath.includes('local') ? '.local' : ''}.buffer.com/logout?redirect=https://${productPath}.buffer.com`);
+  });
+
+  it('return local logout url', () => {
+    const baseUrl = 'https://analyze.local.buffer.com/facebook/overview/4e88a092512f7e1556000000';
+    const productPath = 'analyze.local'
+    expect(getLogoutUrl(baseUrl)).toBe(`https://login${productPath.includes('local') ? '.local' : ''}.buffer.com/logout?redirect=https://${productPath}.buffer.com`);
+  });
+});
+
 
 snap(NavBar, './NavBar.jsx');

--- a/src/components/NavBar/NavBarMenu/NavBarMenu.jsx
+++ b/src/components/NavBar/NavBarMenu/NavBarMenu.jsx
@@ -6,7 +6,7 @@ import {
   NavBarStyled, NavBarEmail, NavBarName, NavBarUser, NavBarAvatar, NavBarChavron,
 } from './style';
 
-function getUserAvatar(user) {
+export function getUserAvatar(user) {
   if (user.avatar) {
     return user.avatar
   }

--- a/src/components/NavBar/NavBarMenu/NavBarMenu.spec.js
+++ b/src/components/NavBar/NavBarMenu/NavBarMenu.spec.js
@@ -1,5 +1,20 @@
 import snap from 'jest-auto-snapshots';
-import NavBarMenu from './NavBarMenu';
+import md5 from 'blueimp-md5';
+import NavBarMenu, { getUserAvatar } from './NavBarMenu';
 import 'jest-styled-components';
+
+describe('Avatar', () => {
+  it('should return existing avatar URL', () => {
+    expect(getUserAvatar({ avatar: 'foo'})).toBe(`foo`);
+  });
+  it('should return gravatar', () => {
+    const user = { email: 'foo@bar.com' };
+    expect(getUserAvatar(user)).toBe(`https://www.gravatar.com/avatar/${md5(user.email)}?d=https%3A%2F%2Fs3.amazonaws.com%2Fbuffer-ui%2FDefault%2BAvatar.png`);
+  });
+});
+
+describe('NavBarMenu methods', () => {
+});
+
 
 snap(NavBarMenu, './NavBarMenu.jsx');

--- a/src/components/NavBar/__snapshots__/NavBar.spec.js.snap
+++ b/src/components/NavBar/__snapshots__/NavBar.spec.js.snap
@@ -59,6 +59,15 @@ exports[`jest-auto-snapshots > NavBar Matches snapshot when array prop "helpMenu
             "onItemClick": [MockFunction],
             "title": "jest-auto-snapshots String Fixture",
           },
+          Object {
+            "hasDivider": true,
+            "icon": <ArrowLeftIcon
+              color="#B8B8B8"
+            />,
+            "id": "logout",
+            "onItemClick": [Function],
+            "title": "Logout",
+          },
         ]
       }
       label=""
@@ -123,6 +132,15 @@ exports[`jest-auto-snapshots > NavBar Matches snapshot when array prop "helpMenu
             "id": "jest-auto-snapshots String Fixture",
             "onItemClick": [MockFunction],
             "title": "jest-auto-snapshots String Fixture",
+          },
+          Object {
+            "hasDivider": true,
+            "icon": <ArrowLeftIcon
+              color="#B8B8B8"
+            />,
+            "id": "logout",
+            "onItemClick": [Function],
+            "title": "Logout",
           },
         ]
       }
@@ -199,6 +217,15 @@ exports[`jest-auto-snapshots > NavBar Matches snapshot when passed all props 1`]
             "onItemClick": [MockFunction],
             "title": "jest-auto-snapshots String Fixture",
           },
+          Object {
+            "hasDivider": true,
+            "icon": <ArrowLeftIcon
+              color="#B8B8B8"
+            />,
+            "id": "logout",
+            "onItemClick": [Function],
+            "title": "Logout",
+          },
         ]
       }
       label=""
@@ -240,6 +267,15 @@ exports[`jest-auto-snapshots > NavBar Matches snapshot when passed only required
             "id": "jest-auto-snapshots String Fixture",
             "onItemClick": [MockFunction],
             "title": "jest-auto-snapshots String Fixture",
+          },
+          Object {
+            "hasDivider": true,
+            "icon": <ArrowLeftIcon
+              color="#B8B8B8"
+            />,
+            "id": "logout",
+            "onItemClick": [Function],
+            "title": "Logout",
           },
         ]
       }

--- a/src/components/NavBar/__snapshots__/NavBar.spec.js.snap
+++ b/src/components/NavBar/__snapshots__/NavBar.spec.js.snap
@@ -53,6 +53,14 @@ exports[`jest-auto-snapshots > NavBar Matches snapshot when array prop "helpMenu
       items={
         Array [
           Object {
+            "icon": <PersonIcon
+              color="#B8B8B8"
+            />,
+            "id": "Account",
+            "onItemClick": [Function],
+            "title": "Account",
+          },
+          Object {
             "component": [MockFunction],
             "hasDivider": true,
             "id": "jest-auto-snapshots String Fixture",
@@ -126,6 +134,14 @@ exports[`jest-auto-snapshots > NavBar Matches snapshot when array prop "helpMenu
       isSplit={false}
       items={
         Array [
+          Object {
+            "icon": <PersonIcon
+              color="#B8B8B8"
+            />,
+            "id": "Account",
+            "onItemClick": [Function],
+            "title": "Account",
+          },
           Object {
             "component": [MockFunction],
             "hasDivider": true,
@@ -211,6 +227,14 @@ exports[`jest-auto-snapshots > NavBar Matches snapshot when passed all props 1`]
       items={
         Array [
           Object {
+            "icon": <PersonIcon
+              color="#B8B8B8"
+            />,
+            "id": "Account",
+            "onItemClick": [Function],
+            "title": "Account",
+          },
+          Object {
             "component": [MockFunction],
             "hasDivider": true,
             "id": "jest-auto-snapshots String Fixture",
@@ -261,6 +285,14 @@ exports[`jest-auto-snapshots > NavBar Matches snapshot when passed only required
       isSplit={false}
       items={
         Array [
+          Object {
+            "icon": <PersonIcon
+              color="#B8B8B8"
+            />,
+            "id": "Account",
+            "onItemClick": [Function],
+            "title": "Account",
+          },
           Object {
             "component": [MockFunction],
             "hasDivider": true,

--- a/src/documentation/examples/AppShell/AppShell.jsx
+++ b/src/documentation/examples/AppShell/AppShell.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import AppShell from '@bufferapp/ui/AppShell';
 import {
-  Person, Gear, ArrowLeft,
+  Person, Gear,
 } from '@bufferapp/ui/Icon';
 
 import { gray } from '@bufferapp/ui/style/colors';
@@ -18,13 +18,6 @@ const userMenuItems = [
     title: 'Preferences',
     icon: <Gear color={gray} />,
     onItemClick: () => {},
-  },
-  {
-    id: '3',
-    title: 'Logout',
-    icon: <ArrowLeft color={gray} />,
-    hasDivider: true,
-    onItemClick: () => console.info('Logout Clicked'),
   },
 ];
 

--- a/src/documentation/examples/AppShell/AppShell.jsx
+++ b/src/documentation/examples/AppShell/AppShell.jsx
@@ -1,18 +1,12 @@
 import React from 'react';
 import AppShell from '@bufferapp/ui/AppShell';
 import {
-  Person, Gear,
+  Gear,
 } from '@bufferapp/ui/Icon';
 
 import { gray } from '@bufferapp/ui/style/colors';
 
 const userMenuItems = [
-  {
-    id: '1',
-    title: 'Account',
-    icon: <Person color={gray} />,
-    onItemClick: () => {},
-  },
   {
     id: '2',
     title: 'Preferences',

--- a/src/documentation/examples/AppShell/WithGravatar.jsx
+++ b/src/documentation/examples/AppShell/WithGravatar.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import AppShell from '@bufferapp/ui/AppShell';
 import {
-  Person, Gear, ArrowLeft,
+  Person, Gear,
 } from '@bufferapp/ui/Icon';
 
 import { gray } from '@bufferapp/ui/style/colors';
@@ -18,13 +18,6 @@ const userMenuItems = [
     title: 'Preferences',
     icon: <Gear color={gray} />,
     onItemClick: () => {},
-  },
-  {
-    id: '3',
-    title: 'Logout',
-    icon: <ArrowLeft color={gray} />,
-    hasDivider: true,
-    onItemClick: () => console.info('Logout Clicked'),
   },
 ];
 

--- a/src/documentation/examples/AppShell/WithGravatar.jsx
+++ b/src/documentation/examples/AppShell/WithGravatar.jsx
@@ -1,18 +1,12 @@
 import React from 'react';
 import AppShell from '@bufferapp/ui/AppShell';
 import {
-  Person, Gear,
+  Gear,
 } from '@bufferapp/ui/Icon';
 
 import { gray } from '@bufferapp/ui/style/colors';
 
 const userMenuItems = [
-  {
-    id: '1',
-    title: 'Account',
-    icon: <Person color={gray} />,
-    onItemClick: () => {},
-  },
   {
     id: '2',
     title: 'Preferences',


### PR DESCRIPTION
This add adds two default items in the user menu: Account, and Logout, with the following structure:
- logout = `https://login.buffer.com/logout?redirect=https://<product-name>.buffer.com`
- account = `https://account.buffer.com/?product=<product_name>&username=<user.name>`

Passing in any extra `user.menuItems` those will be attached in between the two default items
```
[
	account,
	...user.menuItems,
	logout,
]
```