### PR TITLE
add option to ignore default user menu items

### DIFF
--- a/src/components/NavBar/NavBar.jsx
+++ b/src/components/NavBar/NavBar.jsx
@@ -51,6 +51,14 @@ const NavBarHelpText = styled.span`
   margin-left: 8px;
 `;
 
+export function appendMenuItem(ignoreMenuItems, menuItem) {
+  if (!ignoreMenuItems) {
+    return menuItem;
+  }
+
+  return ignoreMenuItems.includes(menuItem.id) ? null : menuItem;
+}
+
 
 /**
  * The NavBar is not consumed alone, but instead is used by the AppShell component. Go check out the AppShell component to learn more.
@@ -79,23 +87,23 @@ const NavBar = ({ activeProduct, user, helpMenuItems }) => (
         hideSearch
         customButton={handleClick => (<NavBarMenu user={user} onClick={handleClick} />)}
         items={[
-          {
-            id: 'Account',
+          (appendMenuItem(user.ignoreMenuItems, {
+            id: 'account',
             title: 'Account',
             icon: <PersonIcon color={gray} />,
             onItemClick: () => { window.location.assign(`https://account.buffer.com?product=${activeProduct}&username=${encodeURI(user.name)}`); },
-          },
+          })),
           ...user.menuItems,
-          {
-              id: 'logout',
-              title: 'Logout',
-              icon: <ArrowLeft color={gray} />,
-              hasDivider: true,
-              onItemClick: () => {
+          (appendMenuItem(user.ignoreMenuItems, {
+            id: 'logout',
+            title: 'Logout',
+            icon: <ArrowLeft color={gray} />,
+            hasDivider: true,
+            onItemClick: () => {
               window.location.assign(getLogoutUrl(window.location.href));
             },
-          },
-        ]}
+          })),
+        ].filter(e => e)}
         horizontalOffset="16px"
       />
     </NavBarRight>
@@ -109,8 +117,10 @@ NavBar.propTypes = {
   user: PropTypes.shape({
     name: PropTypes.string.isRequired,
     email: PropTypes.string.isRequired,
-    // If missing we will use Gravatar to get the user avatar by email
+    /** If missing we will use Gravatar to get the user avatar by email */
     avatar: PropTypes.string,
+    /** If missing we will use Gravatar to get the user avatar by email */
+    ignoreMenuItems: PropTypes.arrayOf(PropTypes.string),
     menuItems: PropTypes.arrayOf(PropTypes.shape({
       id: PropTypes.string.isRequired,
       title: PropTypes.string.isRequired,

--- a/src/components/NavBar/NavBar.spec.js
+++ b/src/components/NavBar/NavBar.spec.js
@@ -1,5 +1,5 @@
 import snap from 'jest-auto-snapshots';
-import NavBar, { getLogoutUrl } from './NavBar';
+import NavBar, { getLogoutUrl, appendMenuItem } from './NavBar';
 
 describe('Logout url', () => {
   it('return logout url', () => {
@@ -13,6 +13,21 @@ describe('Logout url', () => {
     const productPath = 'analyze.local'
     expect(getLogoutUrl(baseUrl)).toBe(`https://login${productPath.includes('local') ? '.local' : ''}.buffer.com/logout?redirect=https://${productPath}.buffer.com`);
   });
+});
+
+describe('Append menu items', () => {
+  it('should return the item if no match', () => {
+    const item = { id: 'foo' };
+    expect(appendMenuItem([], item)).toBe(item);
+
+    expect(appendMenuItem(null, item)).toBe(item);
+  });
+
+  it('should return null if ignoreMenuItems matches', () => {
+    const item = { id: 'foo' };
+    expect(appendMenuItem(['foo'], item)).toBe(null);
+  });
+
 });
 
 

--- a/src/components/NavBar/__snapshots__/NavBar.spec.js.snap
+++ b/src/components/NavBar/__snapshots__/NavBar.spec.js.snap
@@ -56,7 +56,7 @@ exports[`jest-auto-snapshots > NavBar Matches snapshot when array prop "helpMenu
             "icon": <PersonIcon
               color="#B8B8B8"
             />,
-            "id": "Account",
+            "id": "account",
             "onItemClick": [Function],
             "title": "Account",
           },
@@ -138,7 +138,7 @@ exports[`jest-auto-snapshots > NavBar Matches snapshot when array prop "helpMenu
             "icon": <PersonIcon
               color="#B8B8B8"
             />,
-            "id": "Account",
+            "id": "account",
             "onItemClick": [Function],
             "title": "Account",
           },
@@ -230,7 +230,7 @@ exports[`jest-auto-snapshots > NavBar Matches snapshot when passed all props 1`]
             "icon": <PersonIcon
               color="#B8B8B8"
             />,
-            "id": "Account",
+            "id": "account",
             "onItemClick": [Function],
             "title": "Account",
           },
@@ -289,7 +289,7 @@ exports[`jest-auto-snapshots > NavBar Matches snapshot when passed only required
             "icon": <PersonIcon
               color="#B8B8B8"
             />,
-            "id": "Account",
+            "id": "account",
             "onItemClick": [Function],
             "title": "Account",
           },

--- a/src/documentation/examples/AppShell/WithGravatar.jsx
+++ b/src/documentation/examples/AppShell/WithGravatar.jsx
@@ -38,7 +38,7 @@ const helpMenuItems = [
   },
 ];
 
-/** AppShell Example */
+/** AppShell With Gravatar and no Account url */
 export default function ExampleAppShell() {
   return (
     <AppShell
@@ -47,6 +47,7 @@ export default function ExampleAppShell() {
         name: 'Hamish Macpherson',
         email: 'hamstu@gmail.com',
         menuItems: userMenuItems,
+        ignoreMenuItems: ['account'],
       }}
       helpMenuItems={helpMenuItems}
       content={<div>Main content.</div>}


### PR DESCRIPTION
This can be used by Core, to remove the "Account" button from the user
menu.

To ignore an item just pass it's id in `user.ignoreMenuItems`.