### PR TITLE
hide separator if no user.menuItems

### DIFF
--- a/src/components/NavBar/NavBar.jsx
+++ b/src/components/NavBar/NavBar.jsx
@@ -114,7 +114,7 @@ const NavBar = ({ activeProduct, user, helpMenuItems }) => (
             id: 'logout',
             title: 'Logout',
             icon: <ArrowLeft color={gray} />,
-            hasDivider: true,
+            hasDivider: user.menuItems && user.menuItems.length > 0,
             onItemClick: () => {
               window.location.assign(getLogoutUrl(window.location.href));
             },

--- a/src/documentation/examples/AppShell/WithGravatar.jsx
+++ b/src/documentation/examples/AppShell/WithGravatar.jsx
@@ -1,18 +1,7 @@
 import React from 'react';
 import AppShell from '@bufferapp/ui/AppShell';
-import {
-  Gear,
-} from '@bufferapp/ui/Icon';
-
-import { gray } from '@bufferapp/ui/style/colors';
 
 const userMenuItems = [
-  {
-    id: '2',
-    title: 'Preferences',
-    icon: <Gear color={gray} />,
-    onItemClick: () => {},
-  },
 ];
 
 const helpMenuItems = [


### PR DESCRIPTION
We don't need to show the separator if there aren't any additional menu
items. This is needed for Core Account app.