### PR TITLE
removes the calculated height from the AppShell and adds overflow

### DIFF
--- a/src/components/AppShell/style.js
+++ b/src/components/AppShell/style.js
@@ -20,7 +20,7 @@ export const AppShellStyled = styled.div`
 export const Wrapper = styled.div`
   ${flexRow}
   flex: 1;
-  height: calc(100vh - 64px);
+  overflow: auto;
 `;
 
 export const SidebarWrapper = styled.div`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes the Height of the AppShell in Firefox