### PR TITLE
AppShell: add onLogout callback to allow apps to cleanup before logout

### DIFF
--- a/src/components/AppShell/AppShell.jsx
+++ b/src/components/AppShell/AppShell.jsx
@@ -22,6 +22,7 @@ const AppShell = ({
   sidebar,
   content,
   bannerOptions,
+  onLogout,
 }) => (
   <AppShellStyled>
     {/* <GlobalStyles /> */}
@@ -29,6 +30,7 @@ const AppShell = ({
       activeProduct={activeProduct}
       user={user}
       helpMenuItems={helpMenuItems}
+      onLogout={onLogout}
     />
     {bannerOptions && (
       <Banner
@@ -56,7 +58,7 @@ AppShell.propTypes = {
   /** (Optional) Your sidebar component. */
   sidebar: PropTypes.node,
 
-  /** (Optional) Your content component. */
+  /** Your content component. */
   content: PropTypes.node.isRequired,
 
   /** (Optional) Content of banner displayed below the navbar */
@@ -68,12 +70,16 @@ AppShell.propTypes = {
     }),
     customHTML: PropTypes.shape({ __html: PropTypes.string }),
   }),
+
+  /** (Optional) Callback to be called before logout */
+  onLogout: PropTypes.func,
 };
 
 AppShell.defaultProps = {
   sidebar: null,
   activeProduct: undefined,
   bannerOptions: null,
+  onLogout: undefined,
 };
 
 export default AppShell;

--- a/src/components/AppShell/__snapshots__/AppShell.spec.js.snap
+++ b/src/components/AppShell/__snapshots__/AppShell.spec.js.snap
@@ -5,6 +5,7 @@ exports[`jest-auto-snapshots > AppShell Matches snapshot when passed all props 1
   <NavBar
     activeProduct="publish"
     helpMenuItems={null}
+    onLogout={[MockFunction]}
     user={null}
   />
   <Banner

--- a/src/components/NavBar/NavBar.jsx
+++ b/src/components/NavBar/NavBar.jsx
@@ -87,7 +87,7 @@ class NavBar extends React.Component {
   }
 
   render() {
-    const { activeProduct, user, helpMenuItems } = this.props;
+    const { activeProduct, user, helpMenuItems, onLogout } = this.props;
     return (
       <NavBarStyled>
         <NavBarLeft>
@@ -123,7 +123,9 @@ class NavBar extends React.Component {
                 title: 'Account',
                 icon: <PersonIcon color={gray} />,
                 onItemClick: () => {
-                  window.location.assign(getAccountUrl(window.location.href, this.props.user));
+                  window.location.assign(
+                    getAccountUrl(window.location.href, this.props.user)
+                  );
                 },
               }),
               ...user.menuItems,
@@ -133,6 +135,7 @@ class NavBar extends React.Component {
                 icon: <ArrowLeft color={gray} />,
                 hasDivider: user.menuItems && user.menuItems.length > 0,
                 onItemClick: () => {
+                  if (typeof onLogout === 'function') onLogout();
                   window.location.assign(getLogoutUrl(window.location.href));
                 },
               }),
@@ -143,7 +146,7 @@ class NavBar extends React.Component {
       </NavBarStyled>
     );
   }
-};
+}
 
 NavBar.propTypes = {
   /** The currently active (highlighted) product in the `NavBar`, one of `'publish', 'reply', 'analyze'` */
@@ -175,11 +178,14 @@ NavBar.propTypes = {
       onItemClick: PropTypes.func,
     })
   ),
+
+  onLogout: PropTypes.func
 };
 
 NavBar.defaultProps = {
   activeProduct: undefined,
   helpMenuItems: null,
+  onLogout: undefined
 };
 
 export default NavBar;


### PR DESCRIPTION
## Description

Reply is not able to fully logout, because they rely in localStorage. This new property for the `AppShell` would allow a callback to be passed and executed before the redirect to `/logout` happens

## Motivation and Context

Jira: https://buffer.atlassian.net/browse/REPN-158

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style and guidelines of this project. <!--- Link to Standards file coming soon. -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] All new and existing tests passed.
- [ ] I have performed the accessibility audit of my UI changes according to the accessibility doc. <!--- Link to Accessibility Standards file coming soon. -->
- [ ] [Buffer Engineers] Someone from the Design team reviewed and approved my changes
- [ ] [Buffer Engineers] I have notified the BDS team of my changes in the #proj-design-system Slack channel
