### PR TITLE
Adding fallback url prop

### DIFF
--- a/src/components/Avatar/Avatar.jsx
+++ b/src/components/Avatar/Avatar.jsx
@@ -16,6 +16,10 @@ const Image = styled.img`
   ${props => Styles.image[props.type][props.size]}
 `;
 
+const Object = styled.object`
+  ${props => Styles.object[props.size]}
+`;
+
 const socialIconMap = new Map([
   ['instagram', ({ size }) => (
     <Styles.SocialIconWrapper size={size} bgColor={instagram}>
@@ -56,12 +60,15 @@ const Avatar = ({
   size,
   isOnline,
   network,
+  fallbackUrl,
 }) => {
   const SocialIcon = network && socialIconMap.get(network);
   return (
     <Wrapper size={size}>
       {SocialIcon && <SocialIcon size={size} />}
-      <Image size={size} type={type} src={src} alt={alt} />
+      <Object data={src} size={size} type="image/jpg">
+        <Image size={size} type={type} src={fallbackUrl} alt={alt} />
+      </Object>
     </Wrapper>
   );
 };
@@ -71,6 +78,8 @@ Avatar.propTypes = {
   src: PropTypes.string.isRequired,
   /** The alt text for the avatar image. */
   alt: PropTypes.string.isRequired,
+  /** The fallback url for the avatar image. */
+  fallbackUrl: PropTypes.string,
   /** Can be `'default'` (default, plain avatar), `'status'` (online/offline indicator) or `'social'` (has social network icon from the `network` prop). */
   type: PropTypes.oneOf(['default', 'social', 'status']),
   /** Can be `'small'`, `'medium'` or `'large'` (`32px`, `40px` and `48px` respectively). */
@@ -84,6 +93,7 @@ Avatar.propTypes = {
 Avatar.defaultProps = {
   type: 'default',
   size: 'small',
+  fallbackUrl: '',
   isOnline: false,
   network: null,
 };

--- a/src/components/Avatar/__snapshots__/Avatar.spec.js.snap
+++ b/src/components/Avatar/__snapshots__/Avatar.spec.js.snap
@@ -7,12 +7,18 @@ exports[`jest-auto-snapshots > Avatar Matches snapshot when boolean prop "isOnli
   <Unknown
     size="large"
   />
-  <styled.img
-    alt="jest-auto-snapshots String Fixture"
+  <styled.object
+    data="jest-auto-snapshots String Fixture"
     size="large"
-    src="jest-auto-snapshots String Fixture"
-    type="default"
-  />
+    type="image/jpg"
+  >
+    <styled.img
+      alt="jest-auto-snapshots String Fixture"
+      size="large"
+      src="jest-auto-snapshots String Fixture"
+      type="default"
+    />
+  </styled.object>
 </styled.div>
 `;
 
@@ -23,12 +29,18 @@ exports[`jest-auto-snapshots > Avatar Matches snapshot when passed all props 1`]
   <Unknown
     size="large"
   />
-  <styled.img
-    alt="jest-auto-snapshots String Fixture"
+  <styled.object
+    data="jest-auto-snapshots String Fixture"
     size="large"
-    src="jest-auto-snapshots String Fixture"
-    type="default"
-  />
+    type="image/jpg"
+  >
+    <styled.img
+      alt="jest-auto-snapshots String Fixture"
+      size="large"
+      src="jest-auto-snapshots String Fixture"
+      type="default"
+    />
+  </styled.object>
 </styled.div>
 `;
 
@@ -36,11 +48,17 @@ exports[`jest-auto-snapshots > Avatar Matches snapshot when passed only required
 <styled.div
   size="small"
 >
-  <styled.img
-    alt="jest-auto-snapshots String Fixture"
+  <styled.object
+    data="jest-auto-snapshots String Fixture"
     size="small"
-    src="jest-auto-snapshots String Fixture"
-    type="default"
-  />
+    type="image/jpg"
+  >
+    <styled.img
+      alt="jest-auto-snapshots String Fixture"
+      size="small"
+      src=""
+      type="default"
+    />
+  </styled.object>
 </styled.div>
 `;

--- a/src/components/Avatar/style.js
+++ b/src/components/Avatar/style.js
@@ -37,6 +37,20 @@ export const wrapper = {
   large: getWrapperCss({ size: 48 }),
 };
 
+const getObjectCss = ({ size }) => (
+  css`
+    border-radius: 100%;
+    width: ${size}px;
+    height: ${size}px;
+  `
+);
+
+export const object = {
+  small: getObjectCss({ size: 32 }),
+  medium: getObjectCss({ size: 40 }),
+  large: getObjectCss({ size: 48 }),
+};
+
 export const SocialIconWrapper = styled.div`
   position: absolute;
   bottom: 0;

--- a/src/documentation/examples/Avatar/Fallback/AvatarWithFallbackImage.jsx
+++ b/src/documentation/examples/Avatar/Fallback/AvatarWithFallbackImage.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import Avatar from '@bufferapp/ui/Avatar';
+
+/** With Fallback Icon */
+export default function ExampleAvatar() {
+  return (
+    <Avatar
+      src="https://broken-image-url"
+      fallbackUrl="https://s3.amazonaws.com/buffer-ui/Default+Avatar.png"
+      alt="Example"
+      size="large"
+      type="social"
+      network="instagram"
+    />
+  );
+}


### PR DESCRIPTION
## Purpose
When using the Avatar component, when the image is broken the current approach to handle these scenarios (a mask) isn't always working resulting in something like this:

<img width="236" alt="Image 2019-05-17 at 3 56 54 PM" src="https://user-images.githubusercontent.com/988972/57933005-6e3a2580-78bc-11e9-92c2-70c66157224b.png">

I added an optional prop to handle those cases and allowing to send a fallback url to the Avatar component which will display in case the actual image fails to load.

## Description
- I added a prop in the `Avatar` component
- In the `Avatar` component, I surrounded the `Image` tag with an `Object`, which will load the original image, and the Image will load the fallback in case the first one fails.

## Motivation and Context
I decided to include this change because I am able to see it from Publish and I feel like the user experience should be better, and at least with this change the users won't be seeing broken images.

## Screenshots:

**Before the change**

<img width="236" alt="Image 2019-05-17 at 3 56 54 PM" src="https://user-images.githubusercontent.com/988972/57933005-6e3a2580-78bc-11e9-92c2-70c66157224b.png">

**After the change**

<img width="232" alt="Image 2019-05-17 at 3 57 28 PM" src="https://user-images.githubusercontent.com/988972/57933044-81e58c00-78bc-11e9-977f-3b7c7c514016.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style and guidelines of this project. <!--- Link to Standards file coming soon. -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] All new and existing tests passed.
- [ ] I have performed the accessibility audit of my UI changes according to the accessibility doc. <!--- Link to Accessibility Standards file coming soon. -->
- [x] [Buffer Engineers] Someone from the Design team reviewed and approved my changes
- [x] [Buffer Engineers] I have notified the BDS team of my changes in the #proj-design-system Slack channel
