### PR TITLE
Replacing Object tag with a div instead

### DIFF
--- a/src/components/Avatar/Avatar.jsx
+++ b/src/components/Avatar/Avatar.jsx
@@ -12,12 +12,8 @@ const Wrapper = styled.div`
   ${props => Styles.wrapper[props.size]}
 `;
 
-const Image = styled.img`
+const Image = styled.div`
   ${props => Styles.image[props.type][props.size]}
-`;
-
-const Object = styled.object`
-  ${props => Styles.object[props.size]}
 `;
 
 const socialIconMap = new Map([
@@ -66,9 +62,7 @@ const Avatar = ({
   return (
     <Wrapper size={size}>
       {SocialIcon && <SocialIcon size={size} />}
-      <Object data={src} size={size} type="image/jpg">
-        <Image size={size} type={type} src={fallbackUrl} alt={alt} />
-      </Object>
+      <Image size={size} type={type} src={src} fallbackUrl={fallbackUrl} alt={alt} />
     </Wrapper>
   );
 };

--- a/src/components/Avatar/__snapshots__/Avatar.spec.js.snap
+++ b/src/components/Avatar/__snapshots__/Avatar.spec.js.snap
@@ -7,18 +7,13 @@ exports[`jest-auto-snapshots > Avatar Matches snapshot when boolean prop "isOnli
   <Unknown
     size="large"
   />
-  <styled.object
-    data="jest-auto-snapshots String Fixture"
+  <styled.div
+    alt="jest-auto-snapshots String Fixture"
+    fallbackUrl="jest-auto-snapshots String Fixture"
     size="large"
-    type="image/jpg"
-  >
-    <styled.img
-      alt="jest-auto-snapshots String Fixture"
-      size="large"
-      src="jest-auto-snapshots String Fixture"
-      type="default"
-    />
-  </styled.object>
+    src="jest-auto-snapshots String Fixture"
+    type="default"
+  />
 </styled.div>
 `;
 
@@ -29,18 +24,13 @@ exports[`jest-auto-snapshots > Avatar Matches snapshot when passed all props 1`]
   <Unknown
     size="large"
   />
-  <styled.object
-    data="jest-auto-snapshots String Fixture"
+  <styled.div
+    alt="jest-auto-snapshots String Fixture"
+    fallbackUrl="jest-auto-snapshots String Fixture"
     size="large"
-    type="image/jpg"
-  >
-    <styled.img
-      alt="jest-auto-snapshots String Fixture"
-      size="large"
-      src="jest-auto-snapshots String Fixture"
-      type="default"
-    />
-  </styled.object>
+    src="jest-auto-snapshots String Fixture"
+    type="default"
+  />
 </styled.div>
 `;
 
@@ -48,17 +38,12 @@ exports[`jest-auto-snapshots > Avatar Matches snapshot when passed only required
 <styled.div
   size="small"
 >
-  <styled.object
-    data="jest-auto-snapshots String Fixture"
+  <styled.div
+    alt="jest-auto-snapshots String Fixture"
+    fallbackUrl=""
     size="small"
-    type="image/jpg"
-  >
-    <styled.img
-      alt="jest-auto-snapshots String Fixture"
-      size="small"
-      src=""
-      type="default"
-    />
-  </styled.object>
+    src="jest-auto-snapshots String Fixture"
+    type="default"
+  />
 </styled.div>
 `;

--- a/src/components/Avatar/style.js
+++ b/src/components/Avatar/style.js
@@ -7,6 +7,8 @@ const getImageCss = ({ size, type = 'default' }) => (
     border-radius: 100%;
     -webkit-mask-size: cover;
     ${type === 'social' && `-webkit-mask-image: url(https://static.buffer.com/ui/avatar-mask-${size}.svg);`}
+    background: url(${props => props.src}) center no-repeat, url(${props => props.fallbackUrl}) center no-repeat;
+    background-size: ${size}px;
   `
 );
 


### PR DESCRIPTION
## Description
Replaced Object tag with a div instead, and added the fallback url in CSS to make the solution lighter.

## Motivation and Context
Using an Object tag just for a fallback image feels a bit unnecessary, so I updated the CSS to make sure the fallback URL works on all browsers (tested in Chrome, Firefox and Safari) and prevent the use of such a heavy tag.

## Screenshots:
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style and guidelines of this project. <!--- Link to Standards file coming soon. -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] I have performed a self-review of my own code
- [x] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] All new and existing tests passed.
- [ ] I have performed the accessibility audit of my UI changes according to the accessibility doc. <!--- Link to Accessibility Standards file coming soon. -->
- [ ] [Buffer Engineers] Someone from the Design team reviewed and approved my changes
- [ ] [Buffer Engineers] I have notified the BDS team of my changes in the #proj-design-system Slack channel
