### PR TITLE
Don't capitalize button labels

### DIFF
--- a/src/components/Button/style.js
+++ b/src/components/Button/style.js
@@ -165,5 +165,4 @@ export const ButtonArrow = style.div`
 
 export const ButtonLabel = style.div`
   margin-left: ${props => (props.hasIcon ? '5px' : '0px')};
-  text-transform: capitalize;
 `;


### PR DESCRIPTION
## Description
Certain buttons don't look or read well with everything capitalized:

## Screenshots (if appropriate):

Example of buttons with all uppercase (current): ❌

<img width="590" alt="Screen Shot 2019-05-27 at 3 00 41 PM" src="https://user-images.githubusercontent.com/809093/58440656-633b7e00-8090-11e9-85f0-2a927ed6c2ff.png">

Fixed: ✅ 
<img width="590" alt="Screen Shot 2019-05-27 at 3 00 41 PM" src="https://user-images.githubusercontent.com/809093/58440685-b57c9f00-8090-11e9-85b9-d5bc3feee37d.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style and guidelines of this project. <!--- Link to Standards file coming soon. -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] I have performed a self-review of my own code
- [x] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] All new and existing tests passed.
- [ ] I have performed the accessibility audit of my UI changes according to the accessibility doc. <!--- Link to Accessibility Standards file coming soon. -->
- [ ] [Buffer Engineers] Someone from the Design team reviewed and approved my changes
- [ ] [Buffer Engineers] I have notified the BDS team of my changes in the #proj-design-system Slack channel
