### PR TITLE
removes margin from sidebarlistitem

### DIFF
--- a/src/components/SidebarListItem/style.js
+++ b/src/components/SidebarListItem/style.js
@@ -12,7 +12,6 @@ export const ItemStyled = styled.li`
   height: ${props => (props.hasUser ? '48px' : '32px')};
   border-radius: 4px;
   padding-left: 8px;
-  margin-top: 4px;
   background-color: ${props => (props.isSelected ? '#2C4BFF' : 'transparent')};
 `;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
small tweak to remove the margin-top: 4px from SidebarListItem