### PR TITLE
Allow vertical scroll for AppShell content

### DIFF
--- a/src/components/AppShell/style.js
+++ b/src/components/AppShell/style.js
@@ -32,5 +32,5 @@ export const ContentWrapper = styled.div`
   ${flexColumn}
   align-items: center;
   flex: 1;
-  overflow: hidden;
+  overflow: auto;
 `;


### PR DESCRIPTION

## Description

Allows vertical scroll for AppShell content

## Motivation and Context

Right now we can't scroll down on the Account App, if the window height is smaller than the content, that content is not accessible for the user.

If an app needs to remove vertical scrolling, they can always wrap their content within the AppShell with the `overflow: hidden;` CSS rule and it should work well.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style and guidelines of this project. <!--- Link to Standards file coming soon. -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] I have performed a self-review of my own code
- [x] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] All new and existing tests passed.
- [ ] I have performed the accessibility audit of my UI changes according to the accessibility doc. <!--- Link to Accessibility Standards file coming soon. -->
- [ ] [Buffer Engineers] Someone from the Design team reviewed and approved my changes
- [x] [Buffer Engineers] I have notified the BDS team of my changes in the #proj-design-system Slack channel
