### PR TITLE
remove CrossSell export from components/index

### DIFF
--- a/src/components/index.js
+++ b/src/components/index.js
@@ -7,4 +7,3 @@ export { default as Modal } from './Modal';
 export { default as Banner } from './Banner';
 export { default as SidebarListItem } from './SidebarListItem';
 export { default as SidebarHeader } from './SidebarHeader';
-export { default as CrossSell } from './CrossSell';


### PR DESCRIPTION
## Description
Removes CrossSell export from `components/index`.


## Motivation and Context
I'm removing the CrossSell direct export from components/index, as this was breaking tests in Analyze cause of some weird hoisting condition for `styled-components` in nested packages.

Specifically, we noticed this breaking this two PRs:
- https://github.com/bufferapp/buffer-analyze/pull/414
- https://github.com/bufferapp/buffer-analyze/pull/413

![Tests were breaking with the following error](https://user-images.githubusercontent.com/992920/59728472-faf33e80-91ee-11e9-9510-838408700ad3.png)


## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style and guidelines of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] I have performed a self-review of my own code
- [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] All new and existing tests passed.
- [ ] I have performed the accessibility audit of my UI changes according to the accessibility doc. <!--- Link to Accessibility Standards file coming soon. -->
- [ ] [Buffer Engineers] Someone from the Design team reviewed and approved my changes
- [X] [Buffer Engineers] I have notified the BDS team of my changes in the #proj-design-system Slack channel
