### PR TITLE
Add Select example for a Select dropdown where items have no selected state

### DIFF
--- a/src/documentation/examples/Select/SelectWithItemsWithNoSelectedState.jsx
+++ b/src/documentation/examples/Select/SelectWithItemsWithNoSelectedState.jsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import UISelect from '@bufferapp/ui/Select';
+
+class Select extends UISelect {
+  handleSelectOption = (option, event) => {
+    this.props.onSelectClick(option, event)
+    this.setState({
+      isOpen: false,
+    })
+  }
+}
+
+/** Basic Without Selected State On Items */
+export default function ExampleSelect() {
+  return (
+    <Select
+      onSelectClick={() => console.info('Main select clicked')}
+      label="Click Me"
+      keyMap={{
+        id: '_id',
+        title: 'name',
+      }}
+      items={[
+        {
+          _id: '1',
+          name: 'OpenOpenOpenOpenOpenOpenOpenOpenOpen',
+          hotKeyPrompt: 'Q',
+        },
+        { _id: '2', name: 'Pending' },
+        { _id: '3', name: 'Closed' },
+        { _id: '4', name: 'Open' },
+        { _id: '5', name: 'Pending' },
+        { _id: '6', name: 'Closed' },
+        { _id: '7', name: 'Open' },
+        { _id: '8', name: 'Pending' },
+        { _id: '9', name: 'Closed' },
+        { _id: '10', name: 'Open' },
+        { _id: '11', name: 'Pending' },
+        { _id: '23', name: 'Closed' },
+        { _id: '21', name: 'Open' },
+        { _id: '22', name: 'Pending' },
+        { _id: '33', name: 'Closed' },
+        { _id: '41', name: 'Open' },
+        { _id: '52', name: 'Pending' },
+        { _id: '63', name: 'Closed' },
+      ]}
+      hotKeys={[
+        {
+          hotKey: 81,
+          onKeyPress: () => {
+            console.info('hey');
+          },
+        },
+        {
+          hotKey: 87,
+          onKeyPress: () => {
+            console.info('hello there');
+          },
+        },
+      ]}
+      hasCustomAction
+      onCustomItemClick={string => console.info(string)}
+      customItemLabel="Create Tag"
+    />
+  );
+}
+


### PR DESCRIPTION
## Description

Adds a `Select` example in the docs for a Select dropdown where items have no selected state.

## Motivation and Context

We needed a `Select` component in the account application, and creating custom items that had the same styles as the default ones felt too much. This solution felt like it was more maintainable :)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style and guidelines of this project. <!--- Link to Standards file coming soon. -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] I have performed a self-review of my own code
- [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] All new and existing tests passed.
- [ ] I have performed the accessibility audit of my UI changes according to the accessibility doc. <!--- Link to Accessibility Standards file coming soon. -->
- [ ] [Buffer Engineers] Someone from the Design team reviewed and approved my changes
- [] [Buffer Engineers] I have notified the BDS team of my changes in the #proj-design-system Slack channel
