### PR TITLE
Adding zIndex to Tooltip

### DIFF
--- a/src/components/Avatar/Avatar.jsx
+++ b/src/components/Avatar/Avatar.jsx
@@ -81,7 +81,7 @@ Avatar.propTypes = {
   /** Makes the status indictor green when `true`. Only applicable when `{ type: 'status' }` */
   isOnline: PropTypes.bool,
   /** Name of social network icon to overlay. (E.g., `'instagram'`). Only applicable when `{ type: 'social' }` */
-  network: PropTypes.oneOf(['facebook', 'twitter', 'instagram', 'linkedin', 'google']),
+  network: PropTypes.oneOf(['facebook', 'twitter', 'instagram', 'linkedin', 'google', 'pinterest']),
 };
 
 Avatar.defaultProps = {

--- a/src/components/Search/Search.jsx
+++ b/src/components/Search/Search.jsx
@@ -55,7 +55,7 @@ export default class Search extends React.Component {
           onChange={event => this.onChange(event)}
           onClick={onClick}
           clearSearchOnBlur={clearSearchOnBlur}
-          onBlur={clearSearchOnBlur && this.onBlur}
+          onBlur={clearSearchOnBlur ? this.onBlur : undefined}
           height={height}
         />
       </SearchWrapper>

--- a/src/components/Search/__snapshots__/Search.spec.js.snap
+++ b/src/components/Search/__snapshots__/Search.spec.js.snap
@@ -6,7 +6,6 @@ exports[`jest-auto-snapshots > Search Matches snapshot when boolean prop "clearS
     clearSearchOnBlur={false}
     height="jest-auto-snapshots String Fixture"
     innerRef={[Function]}
-    onBlur={false}
     onChange={[Function]}
     onClick={[MockFunction]}
     placeholder="jest-auto-snapshots String Fixture"
@@ -54,7 +53,6 @@ exports[`jest-auto-snapshots > Search Matches snapshot when passed only required
     clearSearchOnBlur={false}
     height="tall"
     innerRef={[Function]}
-    onBlur={false}
     onChange={[Function]}
     onClick={[Function]}
     placeholder=""

--- a/src/components/Tooltip/__snapshots__/Tooltip.spec.js.snap
+++ b/src/components/Tooltip/__snapshots__/Tooltip.spec.js.snap
@@ -32,6 +32,7 @@ exports[`jest-auto-snapshots > Tooltip Matches snapshot when passed all props 1`
         "maxWidth": "200px",
         "padding": "0.5em 1em",
         "whiteSpace": "normal",
+        "zIndex": 9999,
       }
     }
   >
@@ -62,6 +63,7 @@ exports[`jest-auto-snapshots > Tooltip Matches snapshot when passed only require
         "maxWidth": "200px",
         "padding": "0.5em 1em",
         "whiteSpace": "normal",
+        "zIndex": 9999,
       }
     }
   >

--- a/src/components/Tooltip/style.js
+++ b/src/components/Tooltip/style.js
@@ -22,6 +22,7 @@ export const TooltipStyle = {
   padding: "0.5em 1em",
   maxWidth: "200px",
   whiteSpace: "normal",
+  zIndex: 9999,
 }
 
 export const Label = styled.label`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Adding zIndex to Tooltip component to remain visible on top of other elements.
- Fixing Avatar and Search props causing warnings in the console.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When adding the Tooltip on the composer in Publish, the Tooltip is being displayed in the back of the composer, by adding the z-index property we can make sure that the Tooltip has the correct visibility.

## Screenshots:
**Before**
<img width="288" alt="Image 2019-07-18 at 9 51 06 AM" src="https://user-images.githubusercontent.com/988972/61439330-a3f19e00-a941-11e9-993c-7ba952f5c91b.png">

**Now**
<img width="222" alt="Image 2019-07-18 at 9 51 29 AM" src="https://user-images.githubusercontent.com/988972/61439363-b10e8d00-a941-11e9-872f-5033ef4a93e1.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style and guidelines of this project. <!--- Link to Standards file coming soon. -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] I have performed a self-review of my own code
- [x] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] All new and existing tests passed.
- [ ] I have performed the accessibility audit of my UI changes according to the accessibility doc. <!--- Link to Accessibility Standards file coming soon. -->
- [ ] [Buffer Engineers] Someone from the Design team reviewed and approved my changes
- [ ] [Buffer Engineers] I have notified the BDS team of my changes in the #proj-design-system Slack channel
