### PR TITLE
allows attributes to be passed to input

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1935,7 +1935,7 @@
       "resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.2.1.tgz",
       "integrity": "sha512-pUQ0EtCcYm4ormEjJmdk4uzZCxOpaRHB8FDKJXy6q6GqRqQwZ4lAT1f2Tvw0DAmULmyZTpe1/heXY27Tdnct+Q==",
       "requires": {
-        "@reach/component-component": "0.1.3"
+        "@reach/component-component": "^0.1.3"
       }
     },
     "@reach/rect": {
@@ -1943,8 +1943,8 @@
       "resolved": "https://registry.npmjs.org/@reach/rect/-/rect-0.2.1.tgz",
       "integrity": "sha512-aZ9RsNHDMQ3zETonikqu9/85iXxj+LPqZ9Gr9UAncj3AufYmGeWG3XG6b37B+7ORH+mkhVpLU2ZlIWxmOe9Cqg==",
       "requires": {
-        "@reach/component-component": "0.1.3",
-        "@reach/observe-rect": "1.0.3"
+        "@reach/component-component": "^0.1.3",
+        "@reach/observe-rect": "^1.0.3"
       }
     },
     "@reach/tooltip": {
@@ -1953,11 +1953,11 @@
       "integrity": "sha512-afcfqH6EzDHmwTB6g1k0dSbkyT0s9KPIi5bX56nNuldsCIasImFFYDjRZLhFcuxjskwIsHAi06yC3GV6mtcRxw==",
       "requires": {
         "@reach/auto-id": "0.2.0",
-        "@reach/portal": "0.2.1",
-        "@reach/rect": "0.2.1",
-        "@reach/utils": "0.2.3",
-        "@reach/visually-hidden": "0.1.4",
-        "prop-types": "15.7.2"
+        "@reach/portal": "^0.2.1",
+        "@reach/rect": "^0.2.1",
+        "@reach/utils": "^0.2.3",
+        "@reach/visually-hidden": "^0.1.4",
+        "prop-types": "^15.7.2"
       },
       "dependencies": {
         "prop-types": {
@@ -1965,9 +1965,9 @@
           "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
           "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
           "requires": {
-            "loose-envify": "1.4.0",
-            "object-assign": "4.1.1",
-            "react-is": "16.8.6"
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
           }
         },
         "react-is": {
@@ -3101,19 +3101,19 @@
       "dev": true
     },
     "babel-plugin-styled-components": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-1.10.0.tgz",
-      "integrity": "sha512-sQVKG8irFXx14ZfaK1bBePirfkacl3j8nZwSZK+ZjsbnadRHKQTbhXbe/RB1vT6Vgkz45E+V95LBq4KqdhZUNw==",
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-1.10.6.tgz",
+      "integrity": "sha512-gyQj/Zf1kQti66100PhrCRjI5ldjaze9O0M3emXRPAN80Zsf8+e1thpTpaXJXVHXtaM4/+dJEgZHyS9Its+8SA==",
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.0.0",
         "@babel/helper-module-imports": "^7.0.0",
         "babel-plugin-syntax-jsx": "^6.18.0",
-        "lodash": "^4.17.10"
+        "lodash": "^4.17.11"
       }
     },
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
       "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
     },
     "babel-plugin-syntax-object-rest-spread": {
@@ -7223,10 +7223,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "0.6.0",
-            "ini": "1.3.5",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
+            "deep-extend": "^0.6.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -10129,7 +10129,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "minimatch": "3.0.4"
+                "minimatch": "^3.0.4"
               }
             },
             "inflight": {

--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
   "jest": {
     "collectCoverageFrom": [
       "src/components/**/*.{js,jsx}",
-      "!src/components/**/6tyle.js",
+      "!src/components/**/style.js",
       "!src/components/**/index.js"
     ],
     "coverageDirectory": "./coverage/",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "babel-loader": "8.0.4",
     "babel-plugin-module-resolver": "3.1.1",
     "babel-plugin-named-asset-import": "0.2.3",
-    "babel-plugin-styled-components": "1.10.0",
+    "babel-plugin-styled-components": "1.10.6",
     "babel-preset-react-app": "6.1.0",
     "bfj": "6.1.1",
     "case-sensitive-paths-webpack-plugin": "2.1.2",
@@ -160,7 +160,7 @@
   "jest": {
     "collectCoverageFrom": [
       "src/components/**/*.{js,jsx}",
-      "!src/components/**/style.js",
+      "!src/components/**/6tyle.js",
       "!src/components/**/index.js"
     ],
     "coverageDirectory": "./coverage/",

--- a/src/components/Input/Input.jsx
+++ b/src/components/Input/Input.jsx
@@ -17,9 +17,14 @@ const Input = ({
   size,
   type,
   value,
+  ...props
 }) => (
   <Styles.InputWrapper>
-    {label.length > 0 && <Text htmlFor={name} type='label'>{label}</Text>}
+    {label.length > 0 && (
+      <Text htmlFor={name} type="label">
+        {label}
+      </Text>
+    )}
     <Styles.InputStyled
       disabled={disabled}
       hasError={hasError}
@@ -30,11 +35,12 @@ const Input = ({
       type={type}
       size={size}
       value={value}
+      {...props}
     />
     {help.length > 0 && (
       <Styles.HelpTextWrapper>
         {hasError && <Warning size="medium" />}
-        <Styles.HelpText type='help' htmlFor={name} hasError={hasError}>
+        <Styles.HelpText type="help" htmlFor={name} hasError={hasError}>
           {help}
         </Styles.HelpText>
       </Styles.HelpTextWrapper>
@@ -77,6 +83,6 @@ Input.defaultProps = {
   type: 'text',
   value: undefined,
   onBlur: () => {},
-}
+};
 
 export default Input;

--- a/src/components/Input/Input.jsx
+++ b/src/components/Input/Input.jsx
@@ -17,7 +17,7 @@ const Input = ({
   size,
   type,
   value,
-  ...props
+  ref
 }) => (
   <Styles.InputWrapper>
     {label.length > 0 && (
@@ -35,7 +35,7 @@ const Input = ({
       type={type}
       size={size}
       value={value}
-      {...props}
+      ref={ref}
     />
     {help.length > 0 && (
       <Styles.HelpTextWrapper>

--- a/src/components/Input/Input.jsx
+++ b/src/components/Input/Input.jsx
@@ -5,47 +5,51 @@ import * as Styles from './style';
 import { Warning } from '../Icon';
 import Text from '../Text';
 
-const Input = ({
-  disabled,
-  hasError,
-  help,
-  label,
-  name,
-  onChange,
-  onBlur,
-  placeholder,
-  size,
-  type,
-  value,
-  ref
-}) => (
-  <Styles.InputWrapper>
-    {label.length > 0 && (
-      <Text htmlFor={name} type="label">
-        {label}
-      </Text>
-    )}
-    <Styles.InputStyled
-      disabled={disabled}
-      hasError={hasError}
-      name={name}
-      onChange={onChange}
-      onBlur={onBlur}
-      placeholder={placeholder}
-      type={type}
-      size={size}
-      value={value}
-      ref={ref}
-    />
-    {help.length > 0 && (
-      <Styles.HelpTextWrapper>
-        {hasError && <Warning size="medium" />}
-        <Styles.HelpText type="help" htmlFor={name} hasError={hasError}>
-          {help}
-        </Styles.HelpText>
-      </Styles.HelpTextWrapper>
-    )}
-  </Styles.InputWrapper>
+const Input = React.forwardRef(
+  (
+    {
+      disabled,
+      hasError,
+      help,
+      label,
+      name,
+      onChange,
+      onBlur,
+      placeholder,
+      size,
+      type,
+      value,
+    },
+    ref
+  ) => (
+    <Styles.InputWrapper>
+      {label.length > 0 && (
+        <Text htmlFor={name} type="label">
+          {label}
+        </Text>
+      )}
+      <Styles.InputStyled
+        disabled={disabled}
+        hasError={hasError}
+        name={name}
+        onChange={onChange}
+        onBlur={onBlur}
+        placeholder={placeholder}
+        type={type}
+        size={size}
+        value={value}
+        ref={ref}
+      />
+      {help.length > 0 && (
+        <Styles.HelpTextWrapper>
+          {hasError && <Warning size="medium" />}
+          <Styles.HelpText type="help" htmlFor={name} hasError={hasError}>
+            {help}
+          </Styles.HelpText>
+        </Styles.HelpTextWrapper>
+      )}
+    </Styles.InputWrapper>
+  )
 );
 
 Input.propTypes = {
@@ -71,6 +75,8 @@ Input.propTypes = {
   type: PropTypes.string,
   /** The value of the input */
   value: PropTypes.string,
+  /** The prop to get the DOM element of the Button */
+  ref: PropTypes.node,
 };
 
 Input.defaultProps = {
@@ -83,6 +89,7 @@ Input.defaultProps = {
   type: 'text',
   value: undefined,
   onBlur: () => {},
+  ref: undefined,
 };
 
 export default Input;

--- a/src/components/Input/Input.jsx
+++ b/src/components/Input/Input.jsx
@@ -5,9 +5,9 @@ import * as Styles from './style';
 import { Warning } from '../Icon';
 import Text from '../Text';
 
-const Input = React.forwardRef(
-  (
-    {
+export default class Input extends React.Component {
+  render() {
+    const {
       disabled,
       hasError,
       help,
@@ -19,38 +19,38 @@ const Input = React.forwardRef(
       size,
       type,
       value,
-    },
-    ref
-  ) => (
-    <Styles.InputWrapper>
-      {label.length > 0 && (
-        <Text htmlFor={name} type="label">
-          {label}
-        </Text>
-      )}
-      <Styles.InputStyled
-        disabled={disabled}
-        hasError={hasError}
-        name={name}
-        onChange={onChange}
-        onBlur={onBlur}
-        placeholder={placeholder}
-        type={type}
-        size={size}
-        value={value}
-        ref={ref}
-      />
-      {help.length > 0 && (
-        <Styles.HelpTextWrapper>
-          {hasError && <Warning size="medium" />}
-          <Styles.HelpText type="help" htmlFor={name} hasError={hasError}>
-            {help}
-          </Styles.HelpText>
-        </Styles.HelpTextWrapper>
-      )}
-    </Styles.InputWrapper>
-  )
-);
+      forwardRef,
+    } = this.props; 
+    return (
+      <Styles.InputWrapper>
+        {label.length > 0 && (
+          <Text htmlFor={name} type="label">
+            {label}
+          </Text>
+        )}
+        <Styles.InputStyled
+          disabled={disabled}
+          hasError={hasError}
+          name={name}
+          onChange={onChange}
+          onBlur={onBlur}
+          placeholder={placeholder}
+          type={type}
+          size={size}
+          value={value}
+          ref={forwardRef}
+        />
+        {help.length > 0 && (
+          <Styles.HelpTextWrapper>
+            {hasError && <Warning size="medium" />}
+            <Styles.HelpText type="help" htmlFor={name} hasError={hasError}>
+              {help}
+            </Styles.HelpText>
+          </Styles.HelpTextWrapper>
+        )}
+      </Styles.InputWrapper>
+    )}
+};
 
 Input.propTypes = {
   /** It disables the input field. </i> */
@@ -75,8 +75,11 @@ Input.propTypes = {
   type: PropTypes.string,
   /** The value of the input */
   value: PropTypes.string,
-  /** The prop to get the DOM element of the Button */
-  ref: PropTypes.node,
+  /** 
+   * this consumed by the default export that is wrapping the component into a ForwardRef
+   * @ignore
+   */
+  forwardRef: PropTypes.node,
 };
 
 Input.defaultProps = {
@@ -89,7 +92,6 @@ Input.defaultProps = {
   type: 'text',
   value: undefined,
   onBlur: () => {},
-  ref: undefined,
+  forwardRef: undefined,
 };
 
-export default Input;

--- a/src/components/Input/InputWithRef.jsx
+++ b/src/components/Input/InputWithRef.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+import Input from './Input';
+
+// This is a bit ugly but we need it otherwise automatic snapshots tests will fail
+export default React.forwardRef((props, ref) => (<Input {...props} forwardedRef={ref} />));

--- a/src/components/Input/index.js
+++ b/src/components/Input/index.js
@@ -1,1 +1,1 @@
-export { default } from './Input';
+export { default } from './InputWithRef';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
In Reply I needed to pass a `ref` to the input but since we don't have it specified as a prop, it won't allow me. This will let us pass any props to input so we can use it like a native input without having to pass in all the native attributes as props

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style and guidelines of this project. <!--- Link to Standards file coming soon. -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] I have performed a self-review of my own code
- [x] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] All new and existing tests passed.
- [ ] I have performed the accessibility audit of my UI changes according to the accessibility doc. <!--- Link to Accessibility Standards file coming soon. -->
- [ ] [Buffer Engineers] Someone from the Design team reviewed and approved my changes
- [ ] [Buffer Engineers] I have notified the BDS team of my changes in the #proj-design-system Slack channel
