### PR TITLE
Adding a new "dismissible" prop to the Modal component

### DIFF
--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -58,16 +58,18 @@ class Modal extends React.Component {
       setCookie(cookie.store, cookie.key, cookie.days, 'dismissed');
     }
 
-    if (this.props.previousFocus) {
+    if (this.props.previousFocus && this.props.previousFocus.current) {
       this.props.previousFocus.current.focus();
     }
   }
 
   handleAction(action) {
-    if(action.callback) {
+    if (action.callback) {
       action.callback();
     }
-    this.dismiss();
+    if (this.props.dismissible) {
+      this.dismiss();
+    }
   }
 
   render() {
@@ -120,13 +122,15 @@ Modal.propTypes = {
   background: PropTypes.string,
   /** The content of the modal */
   children: PropTypes.node.isRequired,
-    /** The main action settings {**label**: the label of the button,  **disabled** to disable the button, **callback** a callback to invoke on action click, before dismiss */
+  /** The main action settings {**label**: the label of the button,  **disabled** to disable the button, **callback** a callback to invoke on action click, before dismiss */
   action: PropTypes.shape({
     label: PropTypes.string.isRequired,
     disabled: PropTypes.bool,
     callback: PropTypes.func,
   }).isRequired,
-    /** The secondary action settings {**label**: the label of the button, **disabled** to disable the button, **callback** a callback to invoke on action click, before dismiss */
+  /** Verifies if the modal should be dismissed right after the action is executed, in case we are doing a validation inside the modal before closing it */
+  dismissible: PropTypes.bool,
+  /** The secondary action settings {**label**: the label of the button, **disabled** to disable the button, **callback** a callback to invoke on action click, before dismiss */
   secondaryAction: PropTypes.shape({
     label: PropTypes.string.isRequired,
     disabled: PropTypes.bool,
@@ -152,6 +156,7 @@ Modal.defaultProps = {
   footer: null,
   wide: false,
   previousFocus: null,
+  dismissible: true,
 }
 
 export default Modal;

--- a/src/components/Modal/__snapshots__/Modal.spec.jsx.snap
+++ b/src/components/Modal/__snapshots__/Modal.spec.jsx.snap
@@ -1,5 +1,43 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`jest-auto-snapshots > Modal Matches snapshot when boolean prop "dismissible" is set to: "false" 1`] = `
+<ForwardRef(styled.div)>
+  <ForwardRef(styled.section)
+    background="jest-auto-snapshots String Fixture"
+    wide={true}
+  >
+    <NodeFixture />
+    <ForwardRef(styled.div)>
+      <NodeFixture />
+      <Button
+        disabled={true}
+        fullWidth={false}
+        hasIconOnly={false}
+        hideSearch={true}
+        label="jest-auto-snapshots String Fixture"
+        loading={false}
+        onClick={[Function]}
+        selectPosition="bottom"
+        size="medium"
+        type="text"
+      />
+      <Button
+        disabled={true}
+        fullWidth={false}
+        hasIconOnly={false}
+        hideSearch={true}
+        label="jest-auto-snapshots String Fixture"
+        loading={false}
+        onClick={[Function]}
+        selectPosition="bottom"
+        size="medium"
+        type="primary"
+      />
+    </ForwardRef(styled.div)>
+  </ForwardRef(styled.section)>
+</ForwardRef(styled.div)>
+`;
+
 exports[`jest-auto-snapshots > Modal Matches snapshot when boolean prop "wide" is set to: "false" 1`] = `
 <ForwardRef(styled.div)>
   <ForwardRef(styled.section)

--- a/src/documentation/examples/Modal/form-modal.jsx
+++ b/src/documentation/examples/Modal/form-modal.jsx
@@ -18,16 +18,14 @@ export default function FormModalTest() {
         action={{ label: "Don't close yet!" }}
         dismissible={false}
       >
-        <div>
-          <div style={{ width: '100%', padding: '16px', boxSizing: 'border-box' }}>
-            <Text type="h3">Your name here</Text>
-            <Input
-              type='input'
-              onChange={()=>{}}
-              name='foo'
-              placeholder='placeholder text'
-            />
-          </div>
+        <div style={{ width: '100%', padding: '16px', boxSizing: 'border-box' }}>
+          <Text type="h3">Your name here</Text>
+          <Input
+            type='input'
+            onChange={()=>{}}
+            name='foo'
+            placeholder='placeholder text'
+          />
         </div>
       </Modal>
     </div>

--- a/src/documentation/examples/Modal/form-modal.jsx
+++ b/src/documentation/examples/Modal/form-modal.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import Modal from '@bufferapp/ui/Modal';
+import Text from '@bufferapp/ui/Text';
+import Input from '@bufferapp/ui/Input';
+import Button from '@bufferapp/ui/Button';
+
+
+/** Form modal, prevent dismiss until */
+export default function FormModalTest() {
+  return (
+    <div style={{ width: '100%', height: '400px', position: 'relative', padding: '16px', boxSizing: 'border-box' }}>
+      <Button
+        type="primary"
+        onClick={() => {}}
+        label="Bring the modal!"
+      />
+      <Modal
+        action={{ label: "Don't close yet!" }}
+        dismissible={false}
+      >
+        <div>
+          <div style={{ width: '100%', padding: '16px', boxSizing: 'border-box' }}>
+            <Text type="h3">Your name here</Text>
+            <Input
+              type='input'
+              onChange={()=>{}}
+              name='foo'
+              placeholder='placeholder text'
+            />
+          </div>
+        </div>
+      </Modal>
+    </div>
+  );
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adding a new prop to the Modal, to control if the modal is dismissible right after the action in executed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I'm currently using the BDS Modal component for our Billing in Publish, which contains a form, when hitting on Submit, the modal is being dismissed automatically, and we need to check if the fields are valid before closing the modal, with this change, we can send a "dismissible" prop, and prevent closing it before necessary.

The new dismissible prop is set to true by default, so it doesn't affect the modals that are already in use.

## Screenshots:
![Screen Recording 2019-08-09 at 12 08 PM](https://user-images.githubusercontent.com/988972/62771881-7e6a3700-ba9e-11e9-88d3-914f6694c203.gif)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style and guidelines of this project. <!--- Link to Standards file coming soon. -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have updated the **CHANGELOG** document.
- [x] I have added tests to cover my changes.
- [x] I have performed a self-review of my own code
- [x] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] All new and existing tests passed.
- [ ] I have performed the accessibility audit of my UI changes according to the accessibility doc. <!--- Link to Accessibility Standards file coming soon. -->
- [ ] [Buffer Engineers] Someone from the Design team reviewed and approved my changes
- [ ] [Buffer Engineers] I have notified the BDS team of my changes in the #proj-design-system Slack channel
