### PR TITLE
Conditionally render action (button) if provided

### DIFF
--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -126,7 +126,7 @@ Modal.propTypes = {
   background: PropTypes.string,
   /** The content of the modal */
   children: PropTypes.node.isRequired,
-  /** The main action settings {**label**: the label of the button,  **disabled** to disable the button, **callback** a callback to invoke on action click, before dismiss, **hide** a boolean to prevent the button from rendering */
+  /** The main action settings {**label**: the label of the button,  **disabled** to disable the button, **callback** a callback to invoke on action click, before dismiss */
   action: PropTypes.shape({
     label: PropTypes.string.isRequired,
     disabled: PropTypes.bool,
@@ -160,7 +160,7 @@ Modal.defaultProps = {
   footer: null,
   wide: false,
   previousFocus: null,
-  dismissible: true
-}
+  dismissible: true,
+};
 
 export default Modal;

--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -86,8 +86,6 @@ class Modal extends React.Component {
       return null;
     }
 
-    const hasFooterContent = footer || !action.hide || secondaryAction;
-
     return (
       <Styles.Container>
         <Styles.Modal
@@ -96,18 +94,17 @@ class Modal extends React.Component {
           wide={wide}
         >
           {children}
-          {hasFooterContent && (
-            <Styles.Footer>
-              {footer}
-              {secondaryAction && (
-                <Button
-                  type="text"
-                  onClick={() => {this.handleAction(secondaryAction); }}
-                  disabled={secondaryAction.disabled}
-                  label={secondaryAction.label}
-                />
-              )}
-              {!action.hide && (
+          <Styles.Footer>
+            {footer || (
+              <>
+                {secondaryAction && (
+                  <Button
+                    type="text"
+                    onClick={() => {this.handleAction(secondaryAction); }}
+                    disabled={secondaryAction.disabled}
+                    label={secondaryAction.label}
+                  />
+                )}
                 <Button
                   ref={ctaButton => (this.ctaButton = ctaButton)}
                   type="primary"
@@ -115,9 +112,9 @@ class Modal extends React.Component {
                   disabled={action.disabled}
                   label={action.label}
                 />
-              )}
-            </Styles.Footer>
-          )}
+              </>
+            )}
+          </Styles.Footer>
         </Styles.Modal>
       </Styles.Container>
     );
@@ -134,7 +131,6 @@ Modal.propTypes = {
     label: PropTypes.string.isRequired,
     disabled: PropTypes.bool,
     callback: PropTypes.func,
-    hide: PropTypes.bool,
   }).isRequired,
   /** Verifies if the modal should be dismissed right after the action is executed, in case we are doing a validation inside the modal before closing it */
   dismissible: PropTypes.bool,

--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -122,11 +122,12 @@ Modal.propTypes = {
   background: PropTypes.string,
   /** The content of the modal */
   children: PropTypes.node.isRequired,
-  /** The main action settings {**label**: the label of the button,  **disabled** to disable the button, **callback** a callback to invoke on action click, before dismiss */
+  /** The main action settings {**label**: the label of the button,  **disabled** to disable the button, **callback** a callback to invoke on action click, before dismiss, **hide** to prevent the button from rendering */
   action: PropTypes.shape({
     label: PropTypes.string.isRequired,
     disabled: PropTypes.bool,
     callback: PropTypes.func,
+    hide: PropTypes.bool,
   }).isRequired,
   /** Verifies if the modal should be dismissed right after the action is executed, in case we are doing a validation inside the modal before closing it */
   dismissible: PropTypes.bool,

--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -129,7 +129,7 @@ Modal.propTypes = {
   background: PropTypes.string,
   /** The content of the modal */
   children: PropTypes.node.isRequired,
-  /** The main action settings {**label**: the label of the button,  **disabled** to disable the button, **callback** a callback to invoke on action click, before dismiss, **hide** to prevent the button from rendering */
+  /** The main action settings {**label**: the label of the button,  **disabled** to disable the button, **callback** a callback to invoke on action click, before dismiss, **hide** a boolean to prevent the button from rendering */
   action: PropTypes.shape({
     label: PropTypes.string.isRequired,
     disabled: PropTypes.bool,
@@ -165,6 +165,9 @@ Modal.defaultProps = {
   wide: false,
   previousFocus: null,
   dismissible: true,
+  action: {
+    hide: false,
+  },
 }
 
 export default Modal;

--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -103,13 +103,15 @@ class Modal extends React.Component {
                 label={secondaryAction.label}
               />
             )}
-            <Button
-              ref={ctaButton => (this.ctaButton = ctaButton)}
-              type="primary"
-              onClick={() => {this.handleAction(action); }}
-              disabled={action.disabled}
-              label={action.label}
-            />
+            {!action.hide && (
+              <Button
+                ref={ctaButton => (this.ctaButton = ctaButton)}
+                type="primary"
+                onClick={() => {this.handleAction(action); }}
+                disabled={action.disabled}
+                label={action.label}
+              />
+            )}
           </Styles.Footer>
         </Styles.Modal>
       </Styles.Container>

--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -42,13 +42,13 @@ class Modal extends React.Component {
   }
 
   onKeyDown = event => {
-      // ESC
-      if (event.which === 27) {
-        event.preventDefault();
-        event.stopPropagation();
-        this.dismiss();
-      }
-  }
+    // ESC
+    if (event.which === 27) {
+      event.preventDefault();
+      event.stopPropagation();
+      this.dismiss();
+    }
+  };
 
   /** this must be invoked to properly dismiss the modal */
   dismiss() {
@@ -85,7 +85,6 @@ class Modal extends React.Component {
     if (this.state && this.state.dismissed) {
       return null;
     }
-
     return (
       <Styles.Container>
         <Styles.Modal
@@ -100,7 +99,9 @@ class Modal extends React.Component {
                 {secondaryAction && (
                   <Button
                     type="text"
-                    onClick={() => {this.handleAction(secondaryAction); }}
+                    onClick={() => {
+                      this.handleAction(secondaryAction);
+                    }}
                     disabled={secondaryAction.disabled}
                     label={secondaryAction.label}
                   />
@@ -108,7 +109,9 @@ class Modal extends React.Component {
                 <Button
                   ref={ctaButton => (this.ctaButton = ctaButton)}
                   type="primary"
-                  onClick={() => {this.handleAction(action); }}
+                  onClick={() => {
+                    this.handleAction(action);
+                  }}
                   disabled={action.disabled}
                   label={action.label}
                 />

--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -94,28 +94,27 @@ class Modal extends React.Component {
         >
           {children}
           <Styles.Footer>
-            {footer || (
-              <React.Fragment>
-                {secondaryAction && (
-                  <Button
-                    type="text"
-                    onClick={() => {
-                      this.handleAction(secondaryAction);
-                    }}
-                    disabled={secondaryAction.disabled}
-                    label={secondaryAction.label}
-                  />
-                )}
-                <Button
-                  ref={ctaButton => (this.ctaButton = ctaButton)}
-                  type="primary"
-                  onClick={() => {
-                    this.handleAction(action);
-                  }}
-                  disabled={action.disabled}
-                  label={action.label}
-                />
-              </React.Fragment>
+            {footer}
+            {secondaryAction && (
+              <Button
+                type="text"
+                onClick={() => {
+                  this.handleAction(secondaryAction);
+                }}
+                disabled={secondaryAction.disabled}
+                label={secondaryAction.label}
+              />
+            )}
+            {action && (
+              <Button
+                ref={ctaButton => (this.ctaButton = ctaButton)}
+                type="primary"
+                onClick={() => {
+                  this.handleAction(action);
+                }}
+                disabled={action.disabled}
+                label={action.label}
+              />
             )}
           </Styles.Footer>
         </Styles.Modal>
@@ -134,7 +133,7 @@ Modal.propTypes = {
     label: PropTypes.string.isRequired,
     disabled: PropTypes.bool,
     callback: PropTypes.func,
-  }).isRequired,
+  }),
   /** Verifies if the modal should be dismissed right after the action is executed, in case we are doing a validation inside the modal before closing it */
   dismissible: PropTypes.bool,
   /** The secondary action settings {**label**: the label of the button, **disabled** to disable the button, **callback** a callback to invoke on action click, before dismiss */
@@ -159,6 +158,7 @@ Modal.propTypes = {
 Modal.defaultProps = {
   background: null,
   cookie: null,
+  action: null,
   secondaryAction: null,
   footer: null,
   wide: false,

--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -164,10 +164,7 @@ Modal.defaultProps = {
   footer: null,
   wide: false,
   previousFocus: null,
-  dismissible: true,
-  action: {
-    hide: false,
-  },
+  dismissible: true
 }
 
 export default Modal;

--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -96,7 +96,7 @@ class Modal extends React.Component {
           {children}
           <Styles.Footer>
             {footer || (
-              <>
+              <React.Fragment>
                 {secondaryAction && (
                   <Button
                     type="text"
@@ -112,7 +112,7 @@ class Modal extends React.Component {
                   disabled={action.disabled}
                   label={action.label}
                 />
-              </>
+              </React.Fragment>
             )}
           </Styles.Footer>
         </Styles.Modal>

--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -85,6 +85,9 @@ class Modal extends React.Component {
     if (this.state && this.state.dismissed) {
       return null;
     }
+
+    const hasFooterContent = footer || !action.hide || secondaryAction;
+
     return (
       <Styles.Container>
         <Styles.Modal
@@ -93,26 +96,28 @@ class Modal extends React.Component {
           wide={wide}
         >
           {children}
-          <Styles.Footer>
-            {footer}
-            {secondaryAction && (
-              <Button
-                type="text"
-                onClick={() => {this.handleAction(secondaryAction); }}
-                disabled={secondaryAction.disabled}
-                label={secondaryAction.label}
-              />
-            )}
-            {!action.hide && (
-              <Button
-                ref={ctaButton => (this.ctaButton = ctaButton)}
-                type="primary"
-                onClick={() => {this.handleAction(action); }}
-                disabled={action.disabled}
-                label={action.label}
-              />
-            )}
-          </Styles.Footer>
+          {hasFooterContent && (
+            <Styles.Footer>
+              {footer}
+              {secondaryAction && (
+                <Button
+                  type="text"
+                  onClick={() => {this.handleAction(secondaryAction); }}
+                  disabled={secondaryAction.disabled}
+                  label={secondaryAction.label}
+                />
+              )}
+              {!action.hide && (
+                <Button
+                  ref={ctaButton => (this.ctaButton = ctaButton)}
+                  type="primary"
+                  onClick={() => {this.handleAction(action); }}
+                  disabled={action.disabled}
+                  label={action.label}
+                />
+              )}
+            </Styles.Footer>
+          )}
         </Styles.Modal>
       </Styles.Container>
     );

--- a/src/components/Modal/__snapshots__/Modal.spec.jsx.snap
+++ b/src/components/Modal/__snapshots__/Modal.spec.jsx.snap
@@ -9,18 +9,6 @@ exports[`jest-auto-snapshots > Modal Matches snapshot when boolean prop "dismiss
     <NodeFixture />
     <ForwardRef(styled.div)>
       <NodeFixture />
-      <Button
-        disabled={true}
-        fullWidth={false}
-        hasIconOnly={false}
-        hideSearch={true}
-        label="jest-auto-snapshots String Fixture"
-        loading={false}
-        onClick={[Function]}
-        selectPosition="bottom"
-        size="medium"
-        type="text"
-      />
     </ForwardRef(styled.div)>
   </ForwardRef(styled.section)>
 </ForwardRef(styled.div)>
@@ -35,18 +23,6 @@ exports[`jest-auto-snapshots > Modal Matches snapshot when boolean prop "wide" i
     <NodeFixture />
     <ForwardRef(styled.div)>
       <NodeFixture />
-      <Button
-        disabled={true}
-        fullWidth={false}
-        hasIconOnly={false}
-        hideSearch={true}
-        label="jest-auto-snapshots String Fixture"
-        loading={false}
-        onClick={[Function]}
-        selectPosition="bottom"
-        size="medium"
-        type="text"
-      />
     </ForwardRef(styled.div)>
   </ForwardRef(styled.section)>
 </ForwardRef(styled.div)>
@@ -61,18 +37,6 @@ exports[`jest-auto-snapshots > Modal Matches snapshot when passed all props 1`] 
     <NodeFixture />
     <ForwardRef(styled.div)>
       <NodeFixture />
-      <Button
-        disabled={true}
-        fullWidth={false}
-        hasIconOnly={false}
-        hideSearch={true}
-        label="jest-auto-snapshots String Fixture"
-        loading={false}
-        onClick={[Function]}
-        selectPosition="bottom"
-        size="medium"
-        type="text"
-      />
     </ForwardRef(styled.div)>
   </ForwardRef(styled.section)>
 </ForwardRef(styled.div)>
@@ -85,6 +49,22 @@ exports[`jest-auto-snapshots > Modal Matches snapshot when passed only required 
     wide={false}
   >
     <NodeFixture />
+    <ForwardRef(styled.div)>
+      <React.Fragment>
+        <Button
+          disabled={true}
+          fullWidth={false}
+          hasIconOnly={false}
+          hideSearch={true}
+          label="jest-auto-snapshots String Fixture"
+          loading={false}
+          onClick={[Function]}
+          selectPosition="bottom"
+          size="medium"
+          type="primary"
+        />
+      </React.Fragment>
+    </ForwardRef(styled.div)>
   </ForwardRef(styled.section)>
 </ForwardRef(styled.div)>
 `;

--- a/src/components/Modal/__snapshots__/Modal.spec.jsx.snap
+++ b/src/components/Modal/__snapshots__/Modal.spec.jsx.snap
@@ -9,6 +9,30 @@ exports[`jest-auto-snapshots > Modal Matches snapshot when boolean prop "dismiss
     <NodeFixture />
     <ForwardRef(styled.div)>
       <NodeFixture />
+      <Button
+        disabled={true}
+        fullWidth={false}
+        hasIconOnly={false}
+        hideSearch={true}
+        label="jest-auto-snapshots String Fixture"
+        loading={false}
+        onClick={[Function]}
+        selectPosition="bottom"
+        size="medium"
+        type="text"
+      />
+      <Button
+        disabled={true}
+        fullWidth={false}
+        hasIconOnly={false}
+        hideSearch={true}
+        label="jest-auto-snapshots String Fixture"
+        loading={false}
+        onClick={[Function]}
+        selectPosition="bottom"
+        size="medium"
+        type="primary"
+      />
     </ForwardRef(styled.div)>
   </ForwardRef(styled.section)>
 </ForwardRef(styled.div)>
@@ -23,6 +47,30 @@ exports[`jest-auto-snapshots > Modal Matches snapshot when boolean prop "wide" i
     <NodeFixture />
     <ForwardRef(styled.div)>
       <NodeFixture />
+      <Button
+        disabled={true}
+        fullWidth={false}
+        hasIconOnly={false}
+        hideSearch={true}
+        label="jest-auto-snapshots String Fixture"
+        loading={false}
+        onClick={[Function]}
+        selectPosition="bottom"
+        size="medium"
+        type="text"
+      />
+      <Button
+        disabled={true}
+        fullWidth={false}
+        hasIconOnly={false}
+        hideSearch={true}
+        label="jest-auto-snapshots String Fixture"
+        loading={false}
+        onClick={[Function]}
+        selectPosition="bottom"
+        size="medium"
+        type="primary"
+      />
     </ForwardRef(styled.div)>
   </ForwardRef(styled.section)>
 </ForwardRef(styled.div)>
@@ -37,6 +85,30 @@ exports[`jest-auto-snapshots > Modal Matches snapshot when passed all props 1`] 
     <NodeFixture />
     <ForwardRef(styled.div)>
       <NodeFixture />
+      <Button
+        disabled={true}
+        fullWidth={false}
+        hasIconOnly={false}
+        hideSearch={true}
+        label="jest-auto-snapshots String Fixture"
+        loading={false}
+        onClick={[Function]}
+        selectPosition="bottom"
+        size="medium"
+        type="text"
+      />
+      <Button
+        disabled={true}
+        fullWidth={false}
+        hasIconOnly={false}
+        hideSearch={true}
+        label="jest-auto-snapshots String Fixture"
+        loading={false}
+        onClick={[Function]}
+        selectPosition="bottom"
+        size="medium"
+        type="primary"
+      />
     </ForwardRef(styled.div)>
   </ForwardRef(styled.section)>
 </ForwardRef(styled.div)>
@@ -49,22 +121,7 @@ exports[`jest-auto-snapshots > Modal Matches snapshot when passed only required 
     wide={false}
   >
     <NodeFixture />
-    <ForwardRef(styled.div)>
-      <React.Fragment>
-        <Button
-          disabled={true}
-          fullWidth={false}
-          hasIconOnly={false}
-          hideSearch={true}
-          label="jest-auto-snapshots String Fixture"
-          loading={false}
-          onClick={[Function]}
-          selectPosition="bottom"
-          size="medium"
-          type="primary"
-        />
-      </React.Fragment>
-    </ForwardRef(styled.div)>
+    <ForwardRef(styled.div) />
   </ForwardRef(styled.section)>
 </ForwardRef(styled.div)>
 `;

--- a/src/components/Modal/__snapshots__/Modal.spec.jsx.snap
+++ b/src/components/Modal/__snapshots__/Modal.spec.jsx.snap
@@ -21,18 +21,6 @@ exports[`jest-auto-snapshots > Modal Matches snapshot when boolean prop "dismiss
         size="medium"
         type="text"
       />
-      <Button
-        disabled={true}
-        fullWidth={false}
-        hasIconOnly={false}
-        hideSearch={true}
-        label="jest-auto-snapshots String Fixture"
-        loading={false}
-        onClick={[Function]}
-        selectPosition="bottom"
-        size="medium"
-        type="primary"
-      />
     </ForwardRef(styled.div)>
   </ForwardRef(styled.section)>
 </ForwardRef(styled.div)>
@@ -58,18 +46,6 @@ exports[`jest-auto-snapshots > Modal Matches snapshot when boolean prop "wide" i
         selectPosition="bottom"
         size="medium"
         type="text"
-      />
-      <Button
-        disabled={true}
-        fullWidth={false}
-        hasIconOnly={false}
-        hideSearch={true}
-        label="jest-auto-snapshots String Fixture"
-        loading={false}
-        onClick={[Function]}
-        selectPosition="bottom"
-        size="medium"
-        type="primary"
       />
     </ForwardRef(styled.div)>
   </ForwardRef(styled.section)>
@@ -97,18 +73,6 @@ exports[`jest-auto-snapshots > Modal Matches snapshot when passed all props 1`] 
         size="medium"
         type="text"
       />
-      <Button
-        disabled={true}
-        fullWidth={false}
-        hasIconOnly={false}
-        hideSearch={true}
-        label="jest-auto-snapshots String Fixture"
-        loading={false}
-        onClick={[Function]}
-        selectPosition="bottom"
-        size="medium"
-        type="primary"
-      />
     </ForwardRef(styled.div)>
   </ForwardRef(styled.section)>
 </ForwardRef(styled.div)>
@@ -121,20 +85,6 @@ exports[`jest-auto-snapshots > Modal Matches snapshot when passed only required 
     wide={false}
   >
     <NodeFixture />
-    <ForwardRef(styled.div)>
-      <Button
-        disabled={true}
-        fullWidth={false}
-        hasIconOnly={false}
-        hideSearch={true}
-        label="jest-auto-snapshots String Fixture"
-        loading={false}
-        onClick={[Function]}
-        selectPosition="bottom"
-        size="medium"
-        type="primary"
-      />
-    </ForwardRef(styled.div)>
   </ForwardRef(styled.section)>
 </ForwardRef(styled.div)>
 `;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Currently, the `Modal` component always renders an `action` (button).  This PR proposes a change that only renders the action if one is provided.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With recent PSD2 work on Core, we’ve introduced the [Stripe React Elements library](https://stripe.com/payments/elements) . This library basically builds a Stripe payment flow in React and provides some added Stripe functionality. We’ve found that the cleanest and easiest way to implement these forms is to build them with their own button to easily have access to this functionality. Attempting to use the modal’s (parent) button to submit a child form led to quite a few issues - not to mention having to re-implement this across various repos. 

## Screenshots (if appropriate):

<img width="826" alt="Screen Shot 2019-08-30 at 12 42 31 AM" src="https://user-images.githubusercontent.com/51024659/64179327-fc68f600-ce30-11e9-843c-1fe7d7fd2145.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style and guidelines of this project. <!--- Link to Standards file coming soon. -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the **CHANGELOG** document.
- [ ] I have added tests to cover my changes.
- [x] I have performed a self-review of my own code
- [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] All new and existing tests passed.
- [ ] I have performed the accessibility audit of my UI changes according to the accessibility doc. <!--- Link to Accessibility Standards file coming soon. -->
- [ ] [Buffer Engineers] Someone from the Design team reviewed and approved my changes
- [x] [Buffer Engineers] I have notified the BDS team of my changes in the #proj-design-system Slack channel
