### PR TITLE
Add `extraLarge` size option to Icon, to handle 32x32 icons

### DIFF
--- a/src/components/Icon/Icon.jsx
+++ b/src/components/Icon/Icon.jsx
@@ -16,8 +16,8 @@ const Icon = ({ children, ...props }) => (
 );
 
 Icon.propTypes = {
-  /** The size of the icon. Can be 'small', 'medium', or 'large' */
-  size: PropTypes.oneOf(['small', 'medium', 'large']),
+  /** The size of the icon. Can be 'small', 'medium', 'large', or 'extraLarge' */
+  size: PropTypes.oneOf(['small', 'medium', 'large', 'extraLarge']),
 
   /** The `vertical-align` CSS value */
   verticalAlign: PropTypes.string,

--- a/src/components/Icon/style.js
+++ b/src/components/Icon/style.js
@@ -19,3 +19,8 @@ export const large = css`
   width: 22px;
   height: 22px;
 `;
+
+export const extraLarge = css`
+  width: 32px;
+  height: 32px;
+`;

--- a/src/documentation/examples/Icon/SizeExtraLarge.jsx
+++ b/src/documentation/examples/Icon/SizeExtraLarge.jsx
@@ -1,0 +1,11 @@
+
+import React from 'react';
+import LockIcon from '@bufferapp/ui/Icon/Icons/Locked';
+
+/** Size: extra large icon */
+export default function ExtraLargeIcon() {
+  return (
+    <LockIcon size="extraLarge" />
+  );
+}
+

--- a/src/documentation/examples/Icon/SizeLarge.jsx
+++ b/src/documentation/examples/Icon/SizeLarge.jsx
@@ -1,0 +1,11 @@
+
+import React from 'react';
+import LockIcon from '@bufferapp/ui/Icon/Icons/Locked';
+
+/** Size: large icon */
+export default function LargeIcon() {
+  return (
+    <LockIcon size="large" />
+  );
+}
+

--- a/src/documentation/examples/Icon/SizeMedium.jsx
+++ b/src/documentation/examples/Icon/SizeMedium.jsx
@@ -1,0 +1,11 @@
+
+import React from 'react';
+import LockIcon from '@bufferapp/ui/Icon/Icons/Locked';
+
+/** Size: medium icon */
+export default function MediumIcon() {
+  return (
+    <LockIcon size="medium" />
+  );
+}
+

--- a/src/documentation/examples/Icon/SizeSmall.jsx
+++ b/src/documentation/examples/Icon/SizeSmall.jsx
@@ -1,0 +1,11 @@
+
+import React from 'react';
+import LockIcon from '@bufferapp/ui/Icon/Icons/Locked';
+
+/** Size: small icon */
+export default function SmallIcon() {
+  return (
+    <LockIcon size="small" />
+  );
+}
+

--- a/src/documentation/markdown/GettingStarted/Changelog.md
+++ b/src/documentation/markdown/GettingStarted/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [5.4.0] - 2019-09-27
+### Added
+- Adding `extraLarge` size prop to Icon, to handle 32x32 icons.
+
 ## [5.2.4] - 2019-09-05
 ### Added
 - Allow conditional rendering of the Modal component's primary action (button) if an *action* prop is provided.


### PR DESCRIPTION
## Description

Adds an `extraLarge` option to the `size` prop to the `Icon` component to allow for 32x32 icons.

## Motivation and Context

Needing it for designs like [this one](https://cl.ly/946ee1f5d45f), and it also makes sense that we'd have also an Icon with double the size of our `medium` icon.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style and guidelines of this project. <!--- Link to Standards file coming soon. -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated the **CHANGELOG** document.
- [ ] I have added tests to cover my changes.
- [x] I have performed a self-review of my own code
- [x] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] All new and existing tests passed.
- [ ] I have performed the accessibility audit of my UI changes according to the accessibility doc. <!--- Link to Accessibility Standards file coming soon. -->
- [x] [Buffer Engineers] Someone from the Design team reviewed and approved my changes
- [x] [Buffer Engineers] I have notified the BDS team of my changes in the #proj-design-system Slack channel
