### PR TITLE
Fix `ref` forwarding for input

### DIFF
--- a/src/components/Input/Input.jsx
+++ b/src/components/Input/Input.jsx
@@ -20,7 +20,7 @@ export default class Input extends React.Component {
       size,
       type,
       value,
-      forwardRef,
+      forwardedRef,
     } = this.props;
     return (
       <Styles.InputWrapper>
@@ -41,7 +41,7 @@ export default class Input extends React.Component {
             type={type}
             size={size}
             value={value}
-            ref={forwardRef}
+            ref={forwardedRef}
           />
         </Styles.InputFieldWrapper>
         {help.length > 0 && (
@@ -89,7 +89,7 @@ Input.propTypes = {
    * this consumed by the default export that is wrapping the component into a ForwardRef
    * @ignore
    */
-  forwardRef: PropTypes.node,
+  forwardedRef: PropTypes.shape({ current: PropTypes.any }),
 };
 
 Input.defaultProps = {
@@ -102,6 +102,6 @@ Input.defaultProps = {
   type: 'text',
   value: undefined,
   onBlur: () => {},
-  forwardRef: undefined,
+  forwardedRef: undefined,
   prefix: null,
 };

--- a/src/documentation/examples/Input/option/WithExposedRef.jsx
+++ b/src/documentation/examples/Input/option/WithExposedRef.jsx
@@ -1,0 +1,19 @@
+import React, { useRef } from 'react';
+import Input from '@bufferapp/ui/Input';
+
+/** Input with exposed ref */
+export default function ExampleInput() {
+  const inputRef = useRef(null);
+  return (
+    <React.Fragment>
+      <Input
+        onChange={() => {}}
+        name="foo"
+        ref={inputRef}
+      />
+      <button type="button" onClick={() => inputRef.current.focus()}>
+        Focus input
+      </button>
+    </React.Fragment>
+  );
+}

--- a/src/documentation/markdown/GettingStarted/Changelog.md
+++ b/src/documentation/markdown/GettingStarted/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [5.12.2] - 2019-10-29
+### Fixed
+- Fix `ref` forwarding for Input. (The prop names weren't matching.)
+
 ## [5.12.1] - 2019-10-29
 ### Fixed
 - Fix `prefix` position on Input component that also has a label.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixed ref forwarding (prop names were not matched.)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style and guidelines of this project. <!--- Link to Standards file coming soon. -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated the **CHANGELOG** document.
- [x] I have added tests to cover my changes.
- [x] I have performed a self-review of my own code
- [x] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] All new and existing tests passed.
- [x] I have performed the accessibility audit of my UI changes according to the accessibility doc. <!--- Link to Accessibility Standards file coming soon. -->
- [ ] [Buffer Engineers] Someone from the Design team reviewed and approved my changes
- [ ] [Buffer Engineers] I have notified the BDS team of my changes in the #proj-design-system Slack channel
