### PR TITLE
Fix docs generation on npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "test": "jest && npm run lint",
     "test-update": "NODE_ENV=production jest --no-coverage -u",
     "test-watch": "NODE_ENV=production jest --no-coverage --watch",
-    "predeploy:docs": "npm run build:docs",
+    "predeploy:docs": "npm run gen:docs && npm run build:docs",
     "deploy:docs": "gh-pages -d build",
     "prebuild:lib": "rimraf lib",
     "build:lib": "npm-run-all --parallel build:commonjs build:copy-files",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

If the developer does not have the latest component data generated for
the docs, some components might be missing from the documentation after
publishing.

This fixes it by ensuring that any Github pages build triggers that
data generation.

**This won't be a version number upgrade, this is a change done only to our build tools.**

<!--- Describe your changes in detail -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style and guidelines of this project. <!--- Link to Standards file coming soon. -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the **CHANGELOG** document.
- [ ] I have added tests to cover my changes.
- [ ] I have performed a self-review of my own code
- [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] All new and existing tests passed.
- [ ] I have performed the accessibility audit of my UI changes according to the accessibility doc. <!--- Link to Accessibility Standards file coming soon. -->
- [ ] [Buffer Engineers] Someone from the Design team reviewed and approved my changes
- [ ] [Buffer Engineers] I have notified the BDS team of my changes in the #proj-design-system Slack channel
