### PR TITLE
add isOpen param to custom button

### DIFF
--- a/src/components/Select/Select.jsx
+++ b/src/components/Select/Select.jsx
@@ -396,7 +396,7 @@ export default class Select extends React.Component {
       return customButton(this.onButtonClick, this.onSearchChange);
     }
     if (customButton) {
-      return customButton(this.onButtonClick);
+      return customButton(this.onButtonClick, this.state.isOpen);
     }
     if (hasIconOnly) {
       return (

--- a/src/components/Select/Select.jsx
+++ b/src/components/Select/Select.jsx
@@ -396,7 +396,7 @@ export default class Select extends React.Component {
       return customButton(this.onButtonClick, this.onSearchChange);
     }
     if (customButton) {
-      return customButton(this.onButtonClick, this.state.isOpen);
+      return customButton(this.onButtonClick, null, this.state.isOpen);
     }
     if (hasIconOnly) {
       return (

--- a/src/documentation/markdown/GettingStarted/Changelog.md
+++ b/src/documentation/markdown/GettingStarted/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [5.20.0] - 2019-12-11
+### Updated
+- Now passing isOpen state to customButton in Selects to use in outside apps
+
 ## [5.19.0] - 2019-12-09
 ### Fixed
 - Fixed the icon generation script (`npm run gen:icons`) to work with some of the SVGs we're getting back from the Figma API.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
passes isOpen state to customButton

## Motivation and Context
This will help is style the open state of the custom button for the shopify top sources component in Analyze

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/54291087/70575194-f68f5900-1b73-11ea-92c0-f8cd80225bf6.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style and guidelines of this project. <!--- Link to Standards file coming soon. -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated the **CHANGELOG** document.
- [ ] I have added tests to cover my changes.
- [x] I have performed a self-review of my own code
- [x] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] All new and existing tests passed.
- [x] I have performed the accessibility audit of my UI changes according to the accessibility doc. <!--- Link to Accessibility Standards file coming soon. -->
- [ ] [Buffer Engineers] Someone from the Design team reviewed and approved my changes
- [ ] [Buffer Engineers] I have notified the BDS team of my changes in the #proj-design-system Slack channel
