### PR TITLE
Add badge icon sidebar item

### DIFF
--- a/src/components/SidebarListItem/SidebarListItem.jsx
+++ b/src/components/SidebarListItem/SidebarListItem.jsx
@@ -8,6 +8,7 @@ import {
   Handle,
   LabelContainer,
   IconContainer,
+  BadgeIconContainer,
 } from './style';
 import Text from '../Text/Text';
 import Avatar from '../Avatar/Avatar';
@@ -17,6 +18,7 @@ const SidebarListItem = ({
   icon,
   onItemClick,
   badges,
+  badgeIcon,
   selected,
   user,
 }) => (
@@ -50,7 +52,8 @@ const SidebarListItem = ({
       )}
     </LabelContainer>
 
-    {badges && <Badge selected={selected}>{badges}</Badge>}
+    {!badgeIcon && badges && <Badge selected={selected}>{badges}</Badge>}
+    {badgeIcon && <BadgeIconContainer selected={selected}>{badgeIcon}</BadgeIconContainer>}
   </ItemStyled>
 );
 
@@ -65,6 +68,8 @@ SidebarListItem.propTypes = {
   onItemClick: PropTypes.func.isRequired,
   /** A number to display at the far right side of the item */
   badges: PropTypes.number,
+  /** An icon either from this library or a node of your choice */
+  badgeIcon: PropTypes.node,
   /** Whether the item is currently selected */
   selected: PropTypes.bool,
   /** A user object if you'd like the item to display the user Avatar, social network and handle */
@@ -80,6 +85,7 @@ SidebarListItem.propTypes = {
 SidebarListItem.defaultProps = {
   id: '',
   icon: null,
+  badgeIcon: null,
   badges: null,
   selected: null,
   user: null,

--- a/src/components/SidebarListItem/SidebarListItem.jsx
+++ b/src/components/SidebarListItem/SidebarListItem.jsx
@@ -29,6 +29,7 @@ const SidebarListItem = ({
         <React.Fragment>
           <Avatar
             src={user.profileImageUrl}
+            fallbackUrl={user.fallbackUrl}
             alt={user.name}
             size="small"
             type="social"
@@ -66,8 +67,8 @@ SidebarListItem.propTypes = {
   icon: PropTypes.node,
   /** A function to perform when the item is clicked */
   onItemClick: PropTypes.func.isRequired,
-  /** A number to display at the far right side of the item */
-  badges: PropTypes.number,
+  /** A string to display at the far right side of the item */
+  badges: PropTypes.string,
   /** An icon either from this library or a node of your choice */
   badgeIcon: PropTypes.node,
   /** Whether the item is currently selected */
@@ -78,6 +79,7 @@ SidebarListItem.propTypes = {
     name: PropTypes.string,
     handle: PropTypes.string,
     profileImageUrl: PropTypes.string,
+    fallbackUrl: PropTypes.string,
     network: PropTypes.oneOf(['facebook', 'twitter', 'instagram', 'linkedin', 'google', 'pinterest']),
   }),
 };

--- a/src/components/SidebarListItem/__snapshots__/SidebarListItem.spec.js.snap
+++ b/src/components/SidebarListItem/__snapshots__/SidebarListItem.spec.js.snap
@@ -4,6 +4,7 @@ exports[`jest-auto-snapshots > SidebarListItem Matches snapshot when boolean pro
 <ForwardRef(styled.li)
   hasUser={
     Object {
+      "fallbackUrl": "jest-auto-snapshots String Fixture",
       "handle": "jest-auto-snapshots String Fixture",
       "id": "jest-auto-snapshots String Fixture",
       "name": "jest-auto-snapshots String Fixture",
@@ -23,7 +24,7 @@ exports[`jest-auto-snapshots > SidebarListItem Matches snapshot when boolean pro
     <React.Fragment>
       <Avatar
         alt="jest-auto-snapshots String Fixture"
-        fallbackUrl=""
+        fallbackUrl="jest-auto-snapshots String Fixture"
         isOnline={false}
         network="facebook"
         size="small"
@@ -47,11 +48,11 @@ exports[`jest-auto-snapshots > SidebarListItem Matches snapshot when boolean pro
       </ForwardRef(styled.div)>
     </React.Fragment>
   </ForwardRef(styled.div)>
-  <ForwardRef(styled.span)
+  <ForwardRef(Styled(styled.span))
     selected={false}
   >
-    1
-  </ForwardRef(styled.span)>
+    <NodeFixture />
+  </ForwardRef(Styled(styled.span))>
 </ForwardRef(styled.li)>
 `;
 
@@ -59,6 +60,7 @@ exports[`jest-auto-snapshots > SidebarListItem Matches snapshot when passed all 
 <ForwardRef(styled.li)
   hasUser={
     Object {
+      "fallbackUrl": "jest-auto-snapshots String Fixture",
       "handle": "jest-auto-snapshots String Fixture",
       "id": "jest-auto-snapshots String Fixture",
       "name": "jest-auto-snapshots String Fixture",
@@ -78,7 +80,7 @@ exports[`jest-auto-snapshots > SidebarListItem Matches snapshot when passed all 
     <React.Fragment>
       <Avatar
         alt="jest-auto-snapshots String Fixture"
-        fallbackUrl=""
+        fallbackUrl="jest-auto-snapshots String Fixture"
         isOnline={false}
         network="facebook"
         size="small"
@@ -102,11 +104,11 @@ exports[`jest-auto-snapshots > SidebarListItem Matches snapshot when passed all 
       </ForwardRef(styled.div)>
     </React.Fragment>
   </ForwardRef(styled.div)>
-  <ForwardRef(styled.span)
+  <ForwardRef(Styled(styled.span))
     selected={true}
   >
-    1
-  </ForwardRef(styled.span)>
+    <NodeFixture />
+  </ForwardRef(Styled(styled.span))>
 </ForwardRef(styled.li)>
 `;
 

--- a/src/components/SidebarListItem/style.js
+++ b/src/components/SidebarListItem/style.js
@@ -24,7 +24,7 @@ export const Badge = styled.span`
   font-size: 12px;
   line-height: 14px;
   text-align: right;
-  color: ${props => (props.selected ? 'white' : grayDarker)};
+  color: ${props => (props.selected ? white : grayDarker)};
   margin-right: 8px;
 `;
 
@@ -44,7 +44,7 @@ export const Handle = styled.span`
   font-size: 12px;
   line-height: 14px;
   letter-spacing: -0.2px;
-  color: ${props => (props.selected ? 'white' : grayDark)};
+  color: ${props => (props.selected ? white : grayDark)};
 `;
 
 export const LabelContainer = styled.div`
@@ -75,6 +75,6 @@ export const IconContainer = styled.span`
 export const BadgeIconContainer = styled(IconContainer)`
   margin-left: auto;
   svg {
-    fill: ${props => (props.selected ? white : grayDarker)};
+    fill: ${props => (props.selected ? white : 'inherit')};
   }
 `;

--- a/src/components/SidebarListItem/style.js
+++ b/src/components/SidebarListItem/style.js
@@ -75,6 +75,6 @@ export const IconContainer = styled.span`
 export const BadgeIconContainer = styled(IconContainer)`
   margin-left: auto;
   svg {
-    fill: ${props => (props.selected ? white : 'inherit')};
+    fill: ${props => (props.selected ? white : 'currentColor')};
   }
 `;

--- a/src/components/SidebarListItem/style.js
+++ b/src/components/SidebarListItem/style.js
@@ -49,6 +49,7 @@ export const Handle = styled.span`
 
 export const LabelContainer = styled.div`
   display: flex;
+  align-items: center;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
@@ -67,6 +68,13 @@ export const IconContainer = styled.span`
   }
   ${ItemStyled}:hover & * {
     color: ${props => (props.selected ? white : grayDarker)};
+    fill: ${props => (props.selected ? white : grayDarker)};
+  }
+`;
+
+export const BadgeIconContainer = styled(IconContainer)`
+  margin-left: auto;
+  svg {
     fill: ${props => (props.selected ? white : grayDarker)};
   }
 `;

--- a/src/documentation/examples/SidebarListItem/SidebarListItemWithIcon.jsx
+++ b/src/documentation/examples/SidebarListItem/SidebarListItemWithIcon.jsx
@@ -10,7 +10,7 @@ export default function ExampleSidebarListItem() {
       title="Label Default"
       onItemClick={() => console.info('hey')}
       badges={123}
-      badgeIcon={<Warning color="grayDarker" />}
+      badgeIcon={<Warning />}
     />
   );
 }

--- a/src/documentation/examples/SidebarListItem/SidebarListItemWithIcon.jsx
+++ b/src/documentation/examples/SidebarListItem/SidebarListItemWithIcon.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import SidebarListItem from '@bufferapp/ui/SidebarListItem';
+import { Warning } from '@bufferapp/ui/Icon';
+
+/** SidebarListItem With Badge Icon Example */
+export default function ExampleSidebarListItem() {
+  return (
+    <SidebarListItem
+      id="1a"
+      title="Label Default"
+      onItemClick={() => console.info('hey')}
+      badges={123}
+      badgeIcon={<Warning color="grayDarker" />}
+    />
+  );
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Add BadgeIcon, to replace the counter of a SidebarListItem by an icon;
- Add missing `fallbackUrl` prop to the `<Avatar>` on the `SidebarListItem`;
- Change badge proptype to string. 0 is a  falsy value, so passing a number was creating some problems.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
[PUB-1567](https://buffer.atlassian.net/browse/PUB-1567)
We are currently implementing the BDS sidebar in Publish. We needed to make a couple of tweaks to address all use cases: 
- we only display the name and not the handle of the profile;
- sometimes we need the  fallbackUrl for the Avatar; 
- we have a couple of situations where the counter is replaced by an icon - in locked and disconnected accounts. 
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):
<img width="241" alt="Captura de ecrã 2020-01-13, às 11 33 23" src="https://user-images.githubusercontent.com/16758464/72253093-a4b97300-35f8-11ea-8d16-3d506406ecc9.png">
<img width="239" alt="Captura de ecrã 2020-01-13, às 11 33 30" src="https://user-images.githubusercontent.com/16758464/72253100-a7b46380-35f8-11ea-9b29-2b2eb2a55eca.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style and guidelines of this project. <!--- Link to Standards file coming soon. -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have updated the **CHANGELOG** document.
- [x] I have added tests to cover my changes.
- [x] I have performed a self-review of my own code
- [x] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] All new and existing tests passed.
- [ ] I have performed the accessibility audit of my UI changes according to the accessibility doc. <!--- Link to Accessibility Standards file coming soon. -->
- [x] [Buffer Engineers] Someone from the Design team reviewed and approved my changes
- [x] [Buffer Engineers] I have notified the BDS team of my changes in the #proj-design-system Slack channel
