### PR TITLE
extend tooltip to accept customHTML

### DIFF
--- a/src/components/Tooltip/Tooltip.jsx
+++ b/src/components/Tooltip/Tooltip.jsx
@@ -77,7 +77,7 @@ class Tooltip extends React.Component {
   /**
    * Rendering label with hotkey option if available
    */
-  renderLabel = (label, hotkey, customHTML) => (
+  renderLabel = (label, hotkey, customHTML = null) => (
     <Styles.LabelWrapper>
       {label && (
         <Styles.Label
@@ -90,7 +90,7 @@ class Tooltip extends React.Component {
           </Styles.HotkeyWrapper>
         </Styles.Label>
       )}
-      {customHTML && customHTML}
+      {customHTML}
     </Styles.LabelWrapper>
   );
 
@@ -132,7 +132,7 @@ Tooltip.propTypes = {
   hotkey: PropTypes.string,
 
   /** Custom HTML */
-  customHTML: PropTypes.shape({ __html: PropTypes.string }),
+  customHTML: PropTypes.node,
 };
 
 Tooltip.defaultProps = {

--- a/src/components/Tooltip/Tooltip.jsx
+++ b/src/components/Tooltip/Tooltip.jsx
@@ -77,7 +77,7 @@ class Tooltip extends React.Component {
   /**
    * Rendering label with hotkey option if available
    */
-  renderLabel = (label, hotkey) => (
+  renderLabel = (label, hotkey, customHTML) => (
     <Styles.LabelWrapper>
       {label && (
         <Styles.Label
@@ -90,11 +90,12 @@ class Tooltip extends React.Component {
           </Styles.HotkeyWrapper>
         </Styles.Label>
       )}
+      {customHTML && customHTML}
     </Styles.LabelWrapper>
   );
 
   render() {
-    const { children, label, position, hotkey } = this.props;
+    const { children, label, position, hotkey, customHTML } = this.props;
 
     // @todo: remove style from here and use the Styled component
     // We are currently adding the stylings with the style tag,
@@ -104,7 +105,7 @@ class Tooltip extends React.Component {
     return (
       <Styles.TooltipWrapper ref={node => this.tooltipWrapper = node}>
         <Styles.TooltipStyled
-          label={this.renderLabel(label, hotkey)}
+          label={this.renderLabel(label, hotkey, customHTML)}
           position={(triggerRect, tooltipRect) => this.getTooltipPosition(triggerRect, tooltipRect, position)}
           style={Styles.TooltipStyle}
         >
@@ -129,12 +130,16 @@ Tooltip.propTypes = {
 
   /** The tooltip position */
   hotkey: PropTypes.string,
+
+  /** Custom HTML */
+  customHTML: PropTypes.shape({ __html: PropTypes.string }),
 };
 
 Tooltip.defaultProps = {
   label: '',
   position: 'bottom',
   hotkey: '',
+  customHTML: '',
 };
 
 export default Tooltip;

--- a/src/components/Tooltip/__snapshots__/Tooltip.spec.js.snap
+++ b/src/components/Tooltip/__snapshots__/Tooltip.spec.js.snap
@@ -18,9 +18,7 @@ exports[`jest-auto-snapshots > Tooltip Matches snapshot when passed all props 1`
             </ForwardRef(styled.label)>
           </ForwardRef(styled.div)>
         </ForwardRef(styled.label)>
-        Object {
-          "__html": "jest-auto-snapshots String Fixture",
-        }
+        <NodeFixture />
       </ForwardRef(styled.div)>
     }
     position={[Function]}

--- a/src/components/Tooltip/__snapshots__/Tooltip.spec.js.snap
+++ b/src/components/Tooltip/__snapshots__/Tooltip.spec.js.snap
@@ -18,6 +18,9 @@ exports[`jest-auto-snapshots > Tooltip Matches snapshot when passed all props 1`
             </ForwardRef(styled.label)>
           </ForwardRef(styled.div)>
         </ForwardRef(styled.label)>
+        Object {
+          "__html": "jest-auto-snapshots String Fixture",
+        }
       </ForwardRef(styled.div)>
     }
     position={[Function]}
@@ -47,6 +50,7 @@ exports[`jest-auto-snapshots > Tooltip Matches snapshot when passed only require
   <ForwardRef(Styled(Tooltip))
     label={
       <ForwardRef(styled.div)>
+        
         
       </ForwardRef(styled.div)>
     }

--- a/src/documentation/examples/Tooltip/option/multiline.jsx
+++ b/src/documentation/examples/Tooltip/option/multiline.jsx
@@ -7,7 +7,7 @@ export default function ExampleTooltip() {
     return (
       <Tooltip label="My Tooltip Label with multiple lines. Adding up an example here with a long tooltip text.">
         <Avatar
-          src="https://pbs.twimg.com/profile_images/988613046510628866/Io1ZQUpy_400x400.jpg"
+          src="https://s3.amazonaws.com/buffer-ui/Default+Avatar.png"
           alt="@joelgascoigne"
           size="medium"
         />

--- a/src/documentation/examples/Tooltip/option/withCustomHTML.jsx
+++ b/src/documentation/examples/Tooltip/option/withCustomHTML.jsx
@@ -4,8 +4,8 @@ import Avatar from '@bufferapp/ui/Avatar'; // eslint-disable-line
 
 const customHTML = (
   <div>
-    <span style={{ color: '#21F32A', display: 'inline' }}>0.4%</span>
-    <p>potential reach</p>
+    <span style={{ color: '#21F32A'}}>0.4%</span>
+    <p style={{ display: 'inline' }}> potential reach</p>
   </div>
 );
 

--- a/src/documentation/examples/Tooltip/option/withCustomHTML.jsx
+++ b/src/documentation/examples/Tooltip/option/withCustomHTML.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import Tooltip from '@bufferapp/ui/Tooltip';
+import Avatar from '@bufferapp/ui/Avatar'; // eslint-disable-line
+
+const customHTML = (
+  <div>
+    <span style={{ color: '#21F32A', display: 'inline' }}>0.4%</span>
+    <p>potential reach</p>
+  </div>
+);
+
+/** With CustomHTML */
+export default function ExampleTooltip() {
+  return (
+    <Tooltip customHTML={customHTML} position="bottom">
+      <Avatar
+        src="https://pbs.twimg.com/profile_images/988613046510628866/Io1ZQUpy_400x400.jpg"
+        alt="@joelgascoigne"
+        size="medium"
+      />
+    </Tooltip>
+  );
+}

--- a/src/documentation/examples/Tooltip/option/withCustomHTML.jsx
+++ b/src/documentation/examples/Tooltip/option/withCustomHTML.jsx
@@ -14,7 +14,7 @@ export default function ExampleTooltip() {
   return (
     <Tooltip customHTML={customHTML} position="bottom">
       <Avatar
-        src="https://pbs.twimg.com/profile_images/988613046510628866/Io1ZQUpy_400x400.jpg"
+        src="https://s3.amazonaws.com/buffer-ui/Default+Avatar.png"
         alt="@joelgascoigne"
         size="medium"
       />

--- a/src/documentation/examples/Tooltip/option/withHotkey.jsx
+++ b/src/documentation/examples/Tooltip/option/withHotkey.jsx
@@ -7,7 +7,7 @@ export default function ExampleTooltip() {
     return (
       <Tooltip label="My Tooltip Label with multiple lines. Adding up an example here with a long tooltip text." position="bottom" hotkey="⌘+C">
         <Avatar
-          src="https://pbs.twimg.com/profile_images/988613046510628866/Io1ZQUpy_400x400.jpg"
+          src="https://s3.amazonaws.com/buffer-ui/Default+Avatar.png"
           alt="@joelgascoigne"
           size="medium"
         />

--- a/src/documentation/markdown/GettingStarted/Changelog.md
+++ b/src/documentation/markdown/GettingStarted/Changelog.md
@@ -1,4 +1,9 @@
 # Changelog
+
+## [5.24.0] - 2020-02-06
+### Added
+- optional customHTML for tooltips
+
 ## [5.23.1] - 2020-02-03
 ### Added
 - *Flash* icon.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds a customHTML prop like we have in the Banner component to accept custom HTML in the tooltip

## Motivation and Context
We'd like to use this tooltip in Analyze but want to be able to add in highlights and colour as needed

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/54291087/73884716-76643780-4834-11ea-99b4-668d3a2ec69a.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style and guidelines of this project. <!--- Link to Standards file coming soon. -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have updated the **CHANGELOG** document.
- [x] I have added tests to cover my changes.
- [x] I have performed a self-review of my own code
- [x] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] All new and existing tests passed.
- [ ] I have performed the accessibility audit of my UI changes according to the accessibility doc. <!--- Link to Accessibility Standards file coming soon. -->
- [ ] [Buffer Engineers] Someone from the Design team reviewed and approved my changes
- [x] [Buffer Engineers] I have notified the BDS team of my changes in the #proj-design-system Slack channel
