### PR TITLE
extending the modal for Analyze Campaigns

### DIFF
--- a/src/components/Carousel/Carousel.jsx
+++ b/src/components/Carousel/Carousel.jsx
@@ -101,12 +101,28 @@ class Carousel extends React.Component {
 
     // going backwards
     if (currentSlideIndex > index) {
-      if (left === 0) return;
+      // if it's the first slide, loop back to the last one
+      if (left === 0) {
+        const finalLength =
+          (React.Children.count(children) - 1) * parseInt(width, 10);
+        this.setState({
+          left: -finalLength,
+          currentSlideIndex: React.Children.count(children) - 1,
+        });
+        return;
+      }
     }
 
     // going forwards
     if (currentSlideIndex < index) {
-      if (this.verifyLastItem(React.Children.count(children), width)) return;
+      // if it's the last slide, loop back to the first one
+      if (this.verifyLastItem(React.Children.count(children), width)) {
+        this.setState({
+          left: 0,
+          currentSlideIndex: 0,
+        });
+        return;
+      }
     }
 
     const newLeft = parseInt(width, 10) * index;

--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import * as Styles from './style';
 import Button from '../Button';
+import { Cross } from '../Icon';
 
 function setCookie(cookie, cookieKey, days, value) {
   const expiresInDays = days * 24 * 60 * 60;
@@ -46,6 +47,9 @@ class Modal extends React.Component {
     if (event.which === 27) {
       event.preventDefault();
       event.stopPropagation();
+      if (this.props.closeButton) {
+        this.props.closeButton.callback();
+      }
       this.dismiss();
     }
   };
@@ -79,18 +83,41 @@ class Modal extends React.Component {
       secondaryAction,
       footer,
       wide,
+      width,
+      noBackground,
+      closeButton,
     } = this.props;
 
     if (this.state && this.state.dismissed) {
       return null;
     }
+
+    if (wide) {
+      // eslint-disable-next-line
+      console.warn(
+        'WARNING! Obsolete Modal prop `wide`. Deprecated since version 5.32.0. Will be deleted in version 6.0.0. For similar behavior, use `width` prop.'
+      );
+    }
+
     return (
       <Styles.Container>
         <Styles.Modal
           background={background}
           ref={modal => (this.modal = modal)}
           wide={wide}
+          width={width}
+          tabIndex="0" // this needs to have a tabIndex so that it can listen for the ESC key
+          noBackground={noBackground}
         >
+          {closeButton && (
+            <Styles.IconContainer
+              onClick={() => {
+                this.handleAction(closeButton);
+              }}
+            >
+              <Cross />
+            </Styles.IconContainer>
+          )}
           {children}
           <Styles.Footer background={background}>
             {footer}
@@ -148,10 +175,18 @@ Modal.propTypes = {
     key: PropTypes.string.isRequired,
   }),
   footer: PropTypes.node,
-  /** set modal width to 73px */
+  /** set modal width to 730px, this will be deprecated in a future version, use width instead */
   wide: PropTypes.bool,
   /** this element will regain focus on modal close */
   previousFocus: PropTypes.node,
+  /** set a custom modal width, accepts 'wide' as a preset for 730px */
+  width: PropTypes.string,
+  /** remove the background so only the content shows */
+  noBackground: PropTypes.bool,
+  /** adds a close icon, the function to close remains in your app */
+  closeButton: PropTypes.shape({
+    callback: PropTypes.func.isRequired,
+  }),
 };
 
 Modal.defaultProps = {
@@ -163,6 +198,9 @@ Modal.defaultProps = {
   wide: false,
   previousFocus: null,
   dismissible: true,
+  width: null,
+  noBackground: false,
+  closeButton: null,
 };
 
 export default Modal;

--- a/src/components/Modal/__snapshots__/Modal.spec.jsx.snap
+++ b/src/components/Modal/__snapshots__/Modal.spec.jsx.snap
@@ -4,8 +4,66 @@ exports[`jest-auto-snapshots > Modal Matches snapshot when boolean prop "dismiss
 <ForwardRef(styled.div)>
   <ForwardRef(styled.section)
     background="jest-auto-snapshots String Fixture"
+    noBackground={true}
+    tabIndex="0"
     wide={true}
+    width="jest-auto-snapshots String Fixture"
   >
+    <ForwardRef(styled.button)
+      onClick={[Function]}
+    >
+      <CrossIcon />
+    </ForwardRef(styled.button)>
+    <NodeFixture />
+    <ForwardRef(styled.div)
+      background="jest-auto-snapshots String Fixture"
+    >
+      <NodeFixture />
+      <Button
+        disabled={true}
+        fullWidth={false}
+        hasIconOnly={false}
+        hideSearch={true}
+        iconEnd={false}
+        label="jest-auto-snapshots String Fixture"
+        loading={false}
+        onClick={[Function]}
+        selectPosition="bottom"
+        size="medium"
+        type="text"
+      />
+      <Button
+        disabled={true}
+        fullWidth={false}
+        hasIconOnly={false}
+        hideSearch={true}
+        iconEnd={false}
+        label="jest-auto-snapshots String Fixture"
+        loading={false}
+        onClick={[Function]}
+        selectPosition="bottom"
+        size="medium"
+        type="primary"
+      />
+    </ForwardRef(styled.div)>
+  </ForwardRef(styled.section)>
+</ForwardRef(styled.div)>
+`;
+
+exports[`jest-auto-snapshots > Modal Matches snapshot when boolean prop "noBackground" is set to: "false" 1`] = `
+<ForwardRef(styled.div)>
+  <ForwardRef(styled.section)
+    background="jest-auto-snapshots String Fixture"
+    noBackground={false}
+    tabIndex="0"
+    wide={true}
+    width="jest-auto-snapshots String Fixture"
+  >
+    <ForwardRef(styled.button)
+      onClick={[Function]}
+    >
+      <CrossIcon />
+    </ForwardRef(styled.button)>
     <NodeFixture />
     <ForwardRef(styled.div)
       background="jest-auto-snapshots String Fixture"
@@ -46,8 +104,16 @@ exports[`jest-auto-snapshots > Modal Matches snapshot when boolean prop "wide" i
 <ForwardRef(styled.div)>
   <ForwardRef(styled.section)
     background="jest-auto-snapshots String Fixture"
+    noBackground={true}
+    tabIndex="0"
     wide={false}
+    width="jest-auto-snapshots String Fixture"
   >
+    <ForwardRef(styled.button)
+      onClick={[Function]}
+    >
+      <CrossIcon />
+    </ForwardRef(styled.button)>
     <NodeFixture />
     <ForwardRef(styled.div)
       background="jest-auto-snapshots String Fixture"
@@ -88,8 +154,16 @@ exports[`jest-auto-snapshots > Modal Matches snapshot when passed all props 1`] 
 <ForwardRef(styled.div)>
   <ForwardRef(styled.section)
     background="jest-auto-snapshots String Fixture"
+    noBackground={true}
+    tabIndex="0"
     wide={true}
+    width="jest-auto-snapshots String Fixture"
   >
+    <ForwardRef(styled.button)
+      onClick={[Function]}
+    >
+      <CrossIcon />
+    </ForwardRef(styled.button)>
     <NodeFixture />
     <ForwardRef(styled.div)
       background="jest-auto-snapshots String Fixture"
@@ -130,7 +204,10 @@ exports[`jest-auto-snapshots > Modal Matches snapshot when passed only required 
 <ForwardRef(styled.div)>
   <ForwardRef(styled.section)
     background={null}
+    noBackground={false}
+    tabIndex="0"
     wide={false}
+    width={null}
   >
     <NodeFixture />
     <ForwardRef(styled.div)

--- a/src/components/Modal/style.js
+++ b/src/components/Modal/style.js
@@ -1,12 +1,10 @@
 /* eslint-disable no-confusing-arrow */
 import styled from 'styled-components';
-import {
-  white,
-} from '../style/colors';
+import { white } from '../style/colors';
 import { borderRadius } from '../style/borders';
 
 export const Container = styled.div`
-  background: rgba(0, 0, 0, .4);
+  background: rgba(0, 0, 0, 0.4);
   display: flex;
   height: 100%;
   align-items: center;
@@ -20,16 +18,26 @@ export const Container = styled.div`
   left: 0px;
 `;
 
+const getWidth = props => {
+  if (props.wide || props.width === 'wide') {
+    return '730px';
+  }
+  if (props.width) {
+    return props.customWidth;
+  }
+  return '512px';
+};
+
 export const Modal = styled.section`
   background: ${props => props.background};
-  background-color: ${white};
+  background-color: ${props => props.noBackground ? 'transparent': white};
   background-size: 100% auto;
   border-radius: ${borderRadius};
-  box-shadow: 0px 1px 4px rgba(0, 0, 0, 0.16);
+  box-shadow: ${props => props.noBackground ? 'none' : '0px 1px 4px rgba(0, 0, 0, 0.16)'} ;
   box-sizing: border-box;
   margin: 0 0 1rem;
   padding: 16px 0 16px 0;
-  width: ${props => props.wide ? '730px': '512px' };
+  width: ${props => getWidth(props)};
   overflow: hidden;
 
   display: flex;
@@ -39,10 +47,21 @@ export const Modal = styled.section`
   flex-grow: 0;
 `;
 
+export const IconContainer = styled.button`
+  background: none;
+  border: none;
+  position: absolute;
+  top: 32px;
+  right: 32px;
+  svg {
+    fill: #fff;
+  }
+`;
+
 export const Footer = styled.div`
   width: 100%;
   box-sizing: border-box;
-  background: ${props => props.background ? 'transparent' : white};
+  background: ${props => (props.background ? 'transparent' : white)};
   padding: 0 16px;
   margin-top: 16px;
 
@@ -52,7 +71,6 @@ export const Footer = styled.div`
 
   & > span,
   & > p {
-    margin:  0 auto 0 0;
+    margin: 0 auto 0 0;
   }
 `;
-

--- a/src/documentation/examples/Modal/with-carousel.jsx
+++ b/src/documentation/examples/Modal/with-carousel.jsx
@@ -17,26 +17,28 @@ export default function ModalTest() {
       />
       {modalOpen && (
         <Modal
-          action={{ label: 'Don’t Panic!', callback: () => openModal(false) }}
-          wide
+          width="1100px"
+          closeButton={{callback: () => openModal(false)}}
+          noBackground
+          dismissible
         >
           <div>
-            <Carousel width="400px">
-              <img
-                src="https://buffer-analyze.s3.amazonaws.com/images/modal-pro-bg.png"
-                alt="slide 1"
-                width="400"
-              />
-              <img
-                src="https://buffer-analyze.s3.amazonaws.com/images/modal-pro-bg.png"
-                alt="slide 2"
-                width="400"
-              />
-              <img
-                src="https://buffer-analyze.s3.amazonaws.com/images/modal-pro-bg.png"
-                alt="slide 3"
-                width="400"
-              />
+            <Carousel width="1000px">
+              <div
+                style={{ height: '500px', width: '1000px', background: 'red' }}
+              >
+                hello
+              </div>
+              <div
+                style={{ height: '500px', width: '1000px', background: 'blue' }}
+              >
+                hello
+              </div>
+              <div
+                style={{ height: '500px', width: '1000px', background: 'green' }}
+              >
+                hello
+              </div>
             </Carousel>
           </div>
         </Modal>

--- a/src/documentation/markdown/GettingStarted/Changelog.md
+++ b/src/documentation/markdown/GettingStarted/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [5.32.0] - 2020-03-25
+### Fixed
+- Extends Modal component with width, noBackground and closeButton props
+
 ## [5.31.0] - 2020-03-25
 ### Fixed
 - Fixed AppShell after 5.30.0 fix to close popup when selecting an item in the menu


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- adds `customWidth` prop to fit bigger children
- adds `closeCross` prop to add a small cross icon in the top right hand corner (this passes a function that closes the modal from the app)
- adds `noBackground` prop for a floating in mid-air look
- fixes the event listener for the ESC key by adding tabIndex=0 on the Modal so the event registers

## Motivation and Context
We'll need these changes for the modal we're creating in Analyze for Campaigns

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style and guidelines of this project. <!--- Link to Standards file coming soon. -->
- [ ] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [ ] I have updated the **CHANGELOG** document.
- [ ] I have added tests to cover my changes.
- [x] I have performed a self-review of my own code
- [x] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] All new and existing tests passed.
- [ ] I have performed the accessibility audit of my UI changes according to the accessibility doc. <!--- Link to Accessibility Standards file coming soon. -->
- [ ] [Buffer Engineers] Someone from the Design team reviewed and approved my changes
- [ ] [Buffer Engineers] I have notified the BDS team of my changes in the #proj-design-system Slack channel
