### PR TITLE
Allow NavBar to re-render if the contents of "products" prop changes

### DIFF
--- a/src/components/NavBar/NavBar.jsx
+++ b/src/components/NavBar/NavBar.jsx
@@ -110,7 +110,8 @@ export function appendMenuItem(ignoreMenuItems, menuItem) {
 class NavBar extends React.Component {
   shouldComponentUpdate(nextProps) {
     return nextProps.user.name !== this.props.user.name ||
-      nextProps.user.email !== this.props.user.email;
+      nextProps.user.email !== this.props.user.email ||
+      nextProps.products !== this.props.products;
   }
 
   render() {

--- a/src/documentation/markdown/GettingStarted/Changelog.md
+++ b/src/documentation/markdown/GettingStarted/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [5.34.2] - 2020-04-07
+- Allow NavBar to re-render if the contents of "products" prop changes.
+
 ## [5.34.1] - 2020-04-06
 - Fix tests.
 


### PR DESCRIPTION
## Description

This PR includes the changes needed allow the NavBar component to re-render if the contents of "products" prop changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style and guidelines of this project. <!--- Link to Standards file coming soon. -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the **CHANGELOG** document.
- [ ] I have added tests to cover my changes.
- [ ] I have performed a self-review of my own code
- [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] All new and existing tests passed.
- [ ] I have performed the accessibility audit of my UI changes according to the accessibility doc. <!--- Link to Accessibility Standards file coming soon. -->
- [ ] [Buffer Engineers] Someone from the Design team reviewed and approved my changes
- [ ] [Buffer Engineers] I have notified the BDS team of my changes in the #proj-design-system Slack channel
