### PR TITLE
PUB-2532 | Adding aria attributes to select dropdown to make it more semantically accurate

### DIFF
--- a/src/components/Button/Button.jsx
+++ b/src/components/Button/Button.jsx
@@ -5,11 +5,27 @@ import * as Styles from './style';
 import ChevronDown from '../Icon/Icons/ChevronDown';
 import Select from '../Select/Select';
 
-export const ButtonStyled = styled.button`
-  ${Styles.ButtonBase};
-  ${props => Styles[props.size]};
+/*
+Since buttons keep their own inline-block display type, we can only imitate this by using a wrapper (with
+ `display: inline-block`) an internal container (with `display: flex`), and then the actual contents (including real
+  buttons
+ */
+export const ButtonWrapperStyled = styled.div`
+  ${Styles.ButtonWrapperBase};
   ${props => Styles[props.disabled ? 'disabled' : props.type]};
-  ${props => Styles[props.fullWidth ? 'fullWidth' : '']}
+  ${props => (props.fullWidth ? Styles.fullWidth : '')};
+`;
+
+export const ButtonContainerStyled = styled.div`
+  ${Styles.ButtonContainerBase};
+  
+`;
+
+export const ButtonStyled = styled.button`
+  ${Styles.ButtonNestedBase};
+  ${props => Styles[props.size]};
+  ${props => (props.disabled ? Styles.disabled : '')};
+  ${props => (props.fullWidth ? Styles.fullWidth : '')};
 `;
 
 const Loading = styled.img`
@@ -52,68 +68,77 @@ const Button = ({
   className,
   children,
 }) => {
-  /** 
-    Deprecated since version 5.27.0
-    Will be deleted in version 6.0.0
-    For similar behavior, use a Link component.
-    Otherwise choose a different type of button.
-  */
+  /**
+   Deprecated since version 5.27.0
+   Will be deleted in version 6.0.0
+   For similar behavior, use a Link component.
+   Otherwise choose a different type of button.
+   */
   if (type === 'link') {
     // eslint-disable-next-line
-    console.warn('WARNING! Obsolete Link Button. Deprecated since version 5.27.0. Will be deleted in version 6.0.0. For similar behavior, use a Link component. Otherwise choose a different type of button.');
+    console.warn(
+      'WARNING! Obsolete Link Button. Deprecated since version 5.27.0. Will be deleted in version 6.0.0. For similar behavior, use a Link component. Otherwise choose a different type of button.'
+    );
   }
   return (
-    <ButtonStyled
-      onClick={!disabled ? onClick : undefined}
-      disabled={disabled}
-      size={size}
-      type={type}
-      isSplit={isSplit}
-      icon={icon}
-      hasIconOnly={hasIconOnly}
-      fullWidth={fullWidth}
-      data-tip={tooltip}
-      ref={ref}
+    <ButtonWrapperStyled
       className={className}
+      disabled={disabled}
+      type={type}
+      fullWidth={fullWidth}
     >
-      {!iconEnd && icon}
-      {hasIconOnly && <VisuallyHiddenLabel>{label}</VisuallyHiddenLabel>}
-      {!hasIconOnly && (
-        <Styles.ButtonLabel hasIcon={!!icon} iconEnd={!!iconEnd}>
-          {label}
-        </Styles.ButtonLabel>
-      )}
-      {iconEnd && icon}
+      <ButtonContainerStyled>
+        <ButtonStyled
+          onClick={!disabled ? onClick : undefined}
+          disabled={disabled}
+          isSplit={isSplit}
+          icon={icon}
+          hasIconOnly={hasIconOnly}
+          data-tip={tooltip}
+          ref={ref}
+          aria-haspopup="false"
+          size={size}
+          fullWidth={fullWidth}
+        >
+          {!iconEnd && icon}
+          {hasIconOnly && <VisuallyHiddenLabel>{label}</VisuallyHiddenLabel>}
+          {!hasIconOnly && (
+            <Styles.ButtonLabel hasIcon={!!icon} iconEnd={!!iconEnd}>
+              {label}
+            </Styles.ButtonLabel>
+          )}
+          {iconEnd && icon}
 
-      {isSelect && (type === 'primary' || type === 'secondary') && (
-        <Styles.ButtonArrow>
-          <ChevronDown
-            color={type === 'primary' ? 'white' : 'grayDark'}
-            size={size}
-            isChevron
-          />
-        </Styles.ButtonArrow>
-      )}
+          {isSelect && (type === 'primary' || type === 'secondary') && (
+            <Styles.ButtonArrow>
+              <ChevronDown
+                color={type === 'primary' ? 'white' : 'grayDark'}
+                size={size}
+                isChevron
+              />
+            </Styles.ButtonArrow>
+          )}
 
-      {loading && <Loading src="./images/loading-gray.svg" alt="loading" />}
-
-      {isSplit &&
-        (type === 'primary' || type === 'secondary') &&
-        (children ? (
-          React.Children.map(children, child => React.cloneElement(child, {}))
-        ) : (
-          <Select
-            onSelectClick={onSelectClick}
-            items={items}
-            type={type}
-            isSplit
-            yPosition={selectPosition}
-            xPosition="right"
-            disabled={disabled}
-            hideSearch={hideSearch}
-          />
-        ))}
-    </ButtonStyled>
+          {loading && <Loading src="./images/loading-gray.svg" alt="loading" />}
+        </ButtonStyled>
+        {isSplit &&
+          (type === 'primary' || type === 'secondary') &&
+          (children ? (
+            React.Children.map(children, child => React.cloneElement(child, {}))
+          ) : (
+            <Select
+              onSelectClick={onSelectClick}
+              items={items}
+              type={type}
+              isSplit
+              yPosition={selectPosition}
+              xPosition="right"
+              disabled={disabled}
+              hideSearch={hideSearch}
+            />
+          ))}
+      </ButtonContainerStyled>
+    </ButtonWrapperStyled>
   );
 };
 

--- a/src/components/Button/__snapshots__/Button.spec.js.snap
+++ b/src/components/Button/__snapshots__/Button.spec.js.snap
@@ -1,270 +1,366 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`jest-auto-snapshots > Button Matches snapshot when array prop "items" has one item: "[object Object]" 1`] = `
-<ForwardRef(styled.button)
+<ForwardRef(styled.div)
   className="jest-auto-snapshots String Fixture"
-  data-tip="jest-auto-snapshots String Fixture"
   disabled={true}
   fullWidth={true}
-  hasIconOnly={true}
-  icon={<NodeFixture />}
-  isSplit={true}
-  size="small"
   type="link"
 >
-  <ForwardRef(styled.span)>
-    jest-auto-snapshots String Fixture
-  </ForwardRef(styled.span)>
-  <NodeFixture />
-  <ForwardRef(styled.img)
-    alt="loading"
-    src="./images/loading-gray.svg"
-  />
-</ForwardRef(styled.button)>
+  <ForwardRef(styled.div)>
+    <ForwardRef(styled.button)
+      aria-haspopup="false"
+      data-tip="jest-auto-snapshots String Fixture"
+      disabled={true}
+      fullWidth={true}
+      hasIconOnly={true}
+      icon={<NodeFixture />}
+      isSplit={true}
+      size="small"
+    >
+      <ForwardRef(styled.span)>
+        jest-auto-snapshots String Fixture
+      </ForwardRef(styled.span)>
+      <NodeFixture />
+      <ForwardRef(styled.img)
+        alt="loading"
+        src="./images/loading-gray.svg"
+      />
+    </ForwardRef(styled.button)>
+  </ForwardRef(styled.div)>
+</ForwardRef(styled.div)>
 `;
 
 exports[`jest-auto-snapshots > Button Matches snapshot when array prop "items" is an empty array: "[]" 1`] = `
-<ForwardRef(styled.button)
+<ForwardRef(styled.div)
   className="jest-auto-snapshots String Fixture"
-  data-tip="jest-auto-snapshots String Fixture"
   disabled={true}
   fullWidth={true}
-  hasIconOnly={true}
-  icon={<NodeFixture />}
-  isSplit={true}
-  size="small"
   type="link"
 >
-  <ForwardRef(styled.span)>
-    jest-auto-snapshots String Fixture
-  </ForwardRef(styled.span)>
-  <NodeFixture />
-  <ForwardRef(styled.img)
-    alt="loading"
-    src="./images/loading-gray.svg"
-  />
-</ForwardRef(styled.button)>
+  <ForwardRef(styled.div)>
+    <ForwardRef(styled.button)
+      aria-haspopup="false"
+      data-tip="jest-auto-snapshots String Fixture"
+      disabled={true}
+      fullWidth={true}
+      hasIconOnly={true}
+      icon={<NodeFixture />}
+      isSplit={true}
+      size="small"
+    >
+      <ForwardRef(styled.span)>
+        jest-auto-snapshots String Fixture
+      </ForwardRef(styled.span)>
+      <NodeFixture />
+      <ForwardRef(styled.img)
+        alt="loading"
+        src="./images/loading-gray.svg"
+      />
+    </ForwardRef(styled.button)>
+  </ForwardRef(styled.div)>
+</ForwardRef(styled.div)>
 `;
 
 exports[`jest-auto-snapshots > Button Matches snapshot when boolean prop "disabled" is set to: "false" 1`] = `
-<ForwardRef(styled.button)
+<ForwardRef(styled.div)
   className="jest-auto-snapshots String Fixture"
-  data-tip="jest-auto-snapshots String Fixture"
   disabled={false}
   fullWidth={true}
-  hasIconOnly={true}
-  icon={<NodeFixture />}
-  isSplit={true}
-  onClick={[MockFunction]}
-  size="small"
   type="link"
 >
-  <ForwardRef(styled.span)>
-    jest-auto-snapshots String Fixture
-  </ForwardRef(styled.span)>
-  <NodeFixture />
-  <ForwardRef(styled.img)
-    alt="loading"
-    src="./images/loading-gray.svg"
-  />
-</ForwardRef(styled.button)>
+  <ForwardRef(styled.div)>
+    <ForwardRef(styled.button)
+      aria-haspopup="false"
+      data-tip="jest-auto-snapshots String Fixture"
+      disabled={false}
+      fullWidth={true}
+      hasIconOnly={true}
+      icon={<NodeFixture />}
+      isSplit={true}
+      onClick={[MockFunction]}
+      size="small"
+    >
+      <ForwardRef(styled.span)>
+        jest-auto-snapshots String Fixture
+      </ForwardRef(styled.span)>
+      <NodeFixture />
+      <ForwardRef(styled.img)
+        alt="loading"
+        src="./images/loading-gray.svg"
+      />
+    </ForwardRef(styled.button)>
+  </ForwardRef(styled.div)>
+</ForwardRef(styled.div)>
 `;
 
 exports[`jest-auto-snapshots > Button Matches snapshot when boolean prop "fullWidth" is set to: "false" 1`] = `
-<ForwardRef(styled.button)
+<ForwardRef(styled.div)
   className="jest-auto-snapshots String Fixture"
-  data-tip="jest-auto-snapshots String Fixture"
   disabled={true}
   fullWidth={false}
-  hasIconOnly={true}
-  icon={<NodeFixture />}
-  isSplit={true}
-  size="small"
   type="link"
 >
-  <ForwardRef(styled.span)>
-    jest-auto-snapshots String Fixture
-  </ForwardRef(styled.span)>
-  <NodeFixture />
-  <ForwardRef(styled.img)
-    alt="loading"
-    src="./images/loading-gray.svg"
-  />
-</ForwardRef(styled.button)>
+  <ForwardRef(styled.div)>
+    <ForwardRef(styled.button)
+      aria-haspopup="false"
+      data-tip="jest-auto-snapshots String Fixture"
+      disabled={true}
+      fullWidth={false}
+      hasIconOnly={true}
+      icon={<NodeFixture />}
+      isSplit={true}
+      size="small"
+    >
+      <ForwardRef(styled.span)>
+        jest-auto-snapshots String Fixture
+      </ForwardRef(styled.span)>
+      <NodeFixture />
+      <ForwardRef(styled.img)
+        alt="loading"
+        src="./images/loading-gray.svg"
+      />
+    </ForwardRef(styled.button)>
+  </ForwardRef(styled.div)>
+</ForwardRef(styled.div)>
 `;
 
 exports[`jest-auto-snapshots > Button Matches snapshot when boolean prop "hasIconOnly" is set to: "false" 1`] = `
-<ForwardRef(styled.button)
+<ForwardRef(styled.div)
   className="jest-auto-snapshots String Fixture"
-  data-tip="jest-auto-snapshots String Fixture"
   disabled={true}
   fullWidth={true}
-  hasIconOnly={false}
-  icon={<NodeFixture />}
-  isSplit={true}
-  size="small"
   type="link"
 >
-  <ForwardRef(styled.div)
-    hasIcon={true}
-    iconEnd={true}
-  >
-    jest-auto-snapshots String Fixture
+  <ForwardRef(styled.div)>
+    <ForwardRef(styled.button)
+      aria-haspopup="false"
+      data-tip="jest-auto-snapshots String Fixture"
+      disabled={true}
+      fullWidth={true}
+      hasIconOnly={false}
+      icon={<NodeFixture />}
+      isSplit={true}
+      size="small"
+    >
+      <ForwardRef(styled.div)
+        hasIcon={true}
+        iconEnd={true}
+      >
+        jest-auto-snapshots String Fixture
+      </ForwardRef(styled.div)>
+      <NodeFixture />
+      <ForwardRef(styled.img)
+        alt="loading"
+        src="./images/loading-gray.svg"
+      />
+    </ForwardRef(styled.button)>
   </ForwardRef(styled.div)>
-  <NodeFixture />
-  <ForwardRef(styled.img)
-    alt="loading"
-    src="./images/loading-gray.svg"
-  />
-</ForwardRef(styled.button)>
+</ForwardRef(styled.div)>
 `;
 
 exports[`jest-auto-snapshots > Button Matches snapshot when boolean prop "hideSearch" is set to: "false" 1`] = `
-<ForwardRef(styled.button)
+<ForwardRef(styled.div)
   className="jest-auto-snapshots String Fixture"
-  data-tip="jest-auto-snapshots String Fixture"
   disabled={true}
   fullWidth={true}
-  hasIconOnly={true}
-  icon={<NodeFixture />}
-  isSplit={true}
-  size="small"
   type="link"
 >
-  <ForwardRef(styled.span)>
-    jest-auto-snapshots String Fixture
-  </ForwardRef(styled.span)>
-  <NodeFixture />
-  <ForwardRef(styled.img)
-    alt="loading"
-    src="./images/loading-gray.svg"
-  />
-</ForwardRef(styled.button)>
+  <ForwardRef(styled.div)>
+    <ForwardRef(styled.button)
+      aria-haspopup="false"
+      data-tip="jest-auto-snapshots String Fixture"
+      disabled={true}
+      fullWidth={true}
+      hasIconOnly={true}
+      icon={<NodeFixture />}
+      isSplit={true}
+      size="small"
+    >
+      <ForwardRef(styled.span)>
+        jest-auto-snapshots String Fixture
+      </ForwardRef(styled.span)>
+      <NodeFixture />
+      <ForwardRef(styled.img)
+        alt="loading"
+        src="./images/loading-gray.svg"
+      />
+    </ForwardRef(styled.button)>
+  </ForwardRef(styled.div)>
+</ForwardRef(styled.div)>
 `;
 
 exports[`jest-auto-snapshots > Button Matches snapshot when boolean prop "iconEnd" is set to: "false" 1`] = `
-<ForwardRef(styled.button)
+<ForwardRef(styled.div)
   className="jest-auto-snapshots String Fixture"
-  data-tip="jest-auto-snapshots String Fixture"
   disabled={true}
   fullWidth={true}
-  hasIconOnly={true}
-  icon={<NodeFixture />}
-  isSplit={true}
-  size="small"
   type="link"
 >
-  <NodeFixture />
-  <ForwardRef(styled.span)>
-    jest-auto-snapshots String Fixture
-  </ForwardRef(styled.span)>
-  <ForwardRef(styled.img)
-    alt="loading"
-    src="./images/loading-gray.svg"
-  />
-</ForwardRef(styled.button)>
+  <ForwardRef(styled.div)>
+    <ForwardRef(styled.button)
+      aria-haspopup="false"
+      data-tip="jest-auto-snapshots String Fixture"
+      disabled={true}
+      fullWidth={true}
+      hasIconOnly={true}
+      icon={<NodeFixture />}
+      isSplit={true}
+      size="small"
+    >
+      <NodeFixture />
+      <ForwardRef(styled.span)>
+        jest-auto-snapshots String Fixture
+      </ForwardRef(styled.span)>
+      <ForwardRef(styled.img)
+        alt="loading"
+        src="./images/loading-gray.svg"
+      />
+    </ForwardRef(styled.button)>
+  </ForwardRef(styled.div)>
+</ForwardRef(styled.div)>
 `;
 
 exports[`jest-auto-snapshots > Button Matches snapshot when boolean prop "isSelect" is set to: "false" 1`] = `
-<ForwardRef(styled.button)
+<ForwardRef(styled.div)
   className="jest-auto-snapshots String Fixture"
-  data-tip="jest-auto-snapshots String Fixture"
   disabled={true}
   fullWidth={true}
-  hasIconOnly={true}
-  icon={<NodeFixture />}
-  isSplit={true}
-  size="small"
   type="link"
 >
-  <ForwardRef(styled.span)>
-    jest-auto-snapshots String Fixture
-  </ForwardRef(styled.span)>
-  <NodeFixture />
-  <ForwardRef(styled.img)
-    alt="loading"
-    src="./images/loading-gray.svg"
-  />
-</ForwardRef(styled.button)>
+  <ForwardRef(styled.div)>
+    <ForwardRef(styled.button)
+      aria-haspopup="false"
+      data-tip="jest-auto-snapshots String Fixture"
+      disabled={true}
+      fullWidth={true}
+      hasIconOnly={true}
+      icon={<NodeFixture />}
+      isSplit={true}
+      size="small"
+    >
+      <ForwardRef(styled.span)>
+        jest-auto-snapshots String Fixture
+      </ForwardRef(styled.span)>
+      <NodeFixture />
+      <ForwardRef(styled.img)
+        alt="loading"
+        src="./images/loading-gray.svg"
+      />
+    </ForwardRef(styled.button)>
+  </ForwardRef(styled.div)>
+</ForwardRef(styled.div)>
 `;
 
 exports[`jest-auto-snapshots > Button Matches snapshot when boolean prop "isSplit" is set to: "false" 1`] = `
-<ForwardRef(styled.button)
+<ForwardRef(styled.div)
   className="jest-auto-snapshots String Fixture"
-  data-tip="jest-auto-snapshots String Fixture"
   disabled={true}
   fullWidth={true}
-  hasIconOnly={true}
-  icon={<NodeFixture />}
-  isSplit={false}
-  size="small"
   type="link"
 >
-  <ForwardRef(styled.span)>
-    jest-auto-snapshots String Fixture
-  </ForwardRef(styled.span)>
-  <NodeFixture />
-  <ForwardRef(styled.img)
-    alt="loading"
-    src="./images/loading-gray.svg"
-  />
-</ForwardRef(styled.button)>
+  <ForwardRef(styled.div)>
+    <ForwardRef(styled.button)
+      aria-haspopup="false"
+      data-tip="jest-auto-snapshots String Fixture"
+      disabled={true}
+      fullWidth={true}
+      hasIconOnly={true}
+      icon={<NodeFixture />}
+      isSplit={false}
+      size="small"
+    >
+      <ForwardRef(styled.span)>
+        jest-auto-snapshots String Fixture
+      </ForwardRef(styled.span)>
+      <NodeFixture />
+      <ForwardRef(styled.img)
+        alt="loading"
+        src="./images/loading-gray.svg"
+      />
+    </ForwardRef(styled.button)>
+  </ForwardRef(styled.div)>
+</ForwardRef(styled.div)>
 `;
 
 exports[`jest-auto-snapshots > Button Matches snapshot when boolean prop "loading" is set to: "false" 1`] = `
-<ForwardRef(styled.button)
+<ForwardRef(styled.div)
   className="jest-auto-snapshots String Fixture"
-  data-tip="jest-auto-snapshots String Fixture"
   disabled={true}
   fullWidth={true}
-  hasIconOnly={true}
-  icon={<NodeFixture />}
-  isSplit={true}
-  size="small"
   type="link"
 >
-  <ForwardRef(styled.span)>
-    jest-auto-snapshots String Fixture
-  </ForwardRef(styled.span)>
-  <NodeFixture />
-</ForwardRef(styled.button)>
+  <ForwardRef(styled.div)>
+    <ForwardRef(styled.button)
+      aria-haspopup="false"
+      data-tip="jest-auto-snapshots String Fixture"
+      disabled={true}
+      fullWidth={true}
+      hasIconOnly={true}
+      icon={<NodeFixture />}
+      isSplit={true}
+      size="small"
+    >
+      <ForwardRef(styled.span)>
+        jest-auto-snapshots String Fixture
+      </ForwardRef(styled.span)>
+      <NodeFixture />
+    </ForwardRef(styled.button)>
+  </ForwardRef(styled.div)>
+</ForwardRef(styled.div)>
 `;
 
 exports[`jest-auto-snapshots > Button Matches snapshot when passed all props 1`] = `
-<ForwardRef(styled.button)
+<ForwardRef(styled.div)
   className="jest-auto-snapshots String Fixture"
-  data-tip="jest-auto-snapshots String Fixture"
   disabled={true}
   fullWidth={true}
-  hasIconOnly={true}
-  icon={<NodeFixture />}
-  isSplit={true}
-  size="small"
   type="link"
 >
-  <ForwardRef(styled.span)>
-    jest-auto-snapshots String Fixture
-  </ForwardRef(styled.span)>
-  <NodeFixture />
-  <ForwardRef(styled.img)
-    alt="loading"
-    src="./images/loading-gray.svg"
-  />
-</ForwardRef(styled.button)>
+  <ForwardRef(styled.div)>
+    <ForwardRef(styled.button)
+      aria-haspopup="false"
+      data-tip="jest-auto-snapshots String Fixture"
+      disabled={true}
+      fullWidth={true}
+      hasIconOnly={true}
+      icon={<NodeFixture />}
+      isSplit={true}
+      size="small"
+    >
+      <ForwardRef(styled.span)>
+        jest-auto-snapshots String Fixture
+      </ForwardRef(styled.span)>
+      <NodeFixture />
+      <ForwardRef(styled.img)
+        alt="loading"
+        src="./images/loading-gray.svg"
+      />
+    </ForwardRef(styled.button)>
+  </ForwardRef(styled.div)>
+</ForwardRef(styled.div)>
 `;
 
 exports[`jest-auto-snapshots > Button Matches snapshot when passed only required props 1`] = `
-<ForwardRef(styled.button)
+<ForwardRef(styled.div)
   disabled={false}
   fullWidth={false}
-  hasIconOnly={false}
-  onClick={[MockFunction]}
-  size="medium"
   type="secondary"
 >
-  <ForwardRef(styled.div)
-    hasIcon={false}
-    iconEnd={false}
-  />
-</ForwardRef(styled.button)>
+  <ForwardRef(styled.div)>
+    <ForwardRef(styled.button)
+      aria-haspopup="false"
+      disabled={false}
+      fullWidth={false}
+      hasIconOnly={false}
+      onClick={[MockFunction]}
+      size="medium"
+    >
+      <ForwardRef(styled.div)
+        hasIcon={false}
+        iconEnd={false}
+      />
+    </ForwardRef(styled.button)>
+  </ForwardRef(styled.div)>
+</ForwardRef(styled.div)>
 `;

--- a/src/components/Button/style.js
+++ b/src/components/Button/style.js
@@ -80,6 +80,7 @@ export const ButtonNestedBase = css`
   background: none transparent;
   border: 0;
   color: inherit;
+  cursor: pointer;
   display: flex;
   font-family: inherit;
   font-size: inherit;

--- a/src/components/Button/style.js
+++ b/src/components/Button/style.js
@@ -23,43 +23,109 @@ import {
 import { borderRadius } from '../style/borders';
 import { ButtonStyled } from './Button';
 
-/* styles common to all buttons */
-export const ButtonBase = css`
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
-  font-size: ${fontSize};
-  line-height: ${lineHeight};
-  font-weight: ${fontWeightMedium};
-  border-radius: ${borderRadius};
-  cursor: pointer;
-  user-select: none;
-  border: 0;
+export const ButtonWrapperBase = css`
   -webkit-appearance: none;
+  align-items: center;
+  background-color: ${white};
+  border: 0;
+  border-radius: ${borderRadius};
+  box-sizing: border-box;
+  color: ${grayDefault};
+  cursor: pointer;
+  display: inline-block;
+  justify-content: flex-start;
+  flex: 0 0 auto;
+  font-family: ${fontFamily};
+  font-size: ${fontSize};
+  font-weight: ${fontWeightMedium};
+  line-height: ${lineHeight};
+  min-width: 0;
+  padding-top: 0;
+  padding-bottom: 0;
   position: relative;
   transition-property: background-color, border-color, color;
   transition-duration: 0.1s;
   transition-timing-function: ease-in;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  min-width: 0;
-  flex: 0 0 auto;
-  font-family: ${fontFamily};
-  background-color: ${white};
-  color: ${grayDefault};
-  padding-top: 0;
-  padding-bottom: 0;
-  :hover {
-    transition-property: background-color, border-color, color;
-    transition-duration: 0.1s;
-    transition-timing-function: ease-in;
-  }
+  user-select: none;
+
   :active {
     top: 1px;
   }
   :focus {
     box-shadow: 0 0 0 3px ${boxShadow};
     outline: 0;
+  }
+  :hover {
+    transition-property: background-color, border-color, color;
+    transition-duration: 0.1s;
+    transition-timing-function: ease-in;
+  }
+`;
+
+
+export const ButtonContainerBase = css`
+  -webkit-appearance: none;
+  align-items: center;
+  cursor: pointer;
+  display: flex;
+  justify-content: flex-start;
+  flex: 0 0 auto;
+  user-select: none;
+  width: 100%;
+  height: 100%;
+`;
+
+export const ButtonNestedBase = css`
+  align-items: center;
+  background: none transparent;
+  border: 0;
+  color: inherit;
+  display: flex;
+  font-family: inherit;
+  font-size: inherit;
+  font-weight: inherit;
+  justify-content: flex-start;
+  margin: -1px;
+  padding: 0;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  width: 100%;
+`;
+
+/* styles common to all buttons */
+export const ButtonBase = css`
+  -webkit-appearance: none;
+  align-items: center;
+  background-color: ${white};
+  border: 0;
+  border-radius: ${borderRadius};
+  color: ${grayDefault};
+  cursor: pointer;
+  display: flex;
+  justify-content: flex-start;
+  flex: 0 0 auto;
+  font-family: ${fontFamily};
+  font-size: ${fontSize};
+  font-weight: ${fontWeightMedium};
+  line-height: ${lineHeight};
+  min-width: 0;
+  padding-top: 0;
+  padding-bottom: 0;
+  position: relative;
+  transition-property: background-color, border-color, color;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in;
+  user-select: none;
+  :active {
+    top: 1px;
+  }
+  :focus {
+    box-shadow: 0 0 0 3px ${boxShadow};
+  }
+  :hover {
+    transition-property: background-color, border-color, color;
+    transition-duration: 0.1s;
+    transition-timing-function: ease-in;
   }
 `;
 
@@ -149,18 +215,22 @@ export const ButtonSelect = style.div`
     color: ${props => (props.disabled ? gray : blueLighter)};
     content: "";
     height: 24px;
+    left: 0;
     position: absolute;
-    right: 34px;
     top: 50%;
     transform: translateY(-50%);
     width: 1px;
   }
-  padding-left: 13px;
-  display: flex;
-  justify-content: center;
+
   align-items: center;
-  width: 100%;
+  display: flex;
   height: 38px;
+  justify-content: center;
+  box-sizing: border-box;
+  padding: 0 10px;
+  position: relative;
+  width: 100%;
+
   ${ButtonStyled}:hover & {
     background-color: ${blueDark};
     color: ${white};

--- a/src/components/Select/Select.jsx
+++ b/src/components/Select/Select.jsx
@@ -549,6 +549,8 @@ export default class Select extends React.Component {
         ref={selectNode => (this.selectNode = selectNode)}
         data-tip={disabled ? '' : tooltip}
         fullWidth={fullWidth}
+        aria-haspopup="true"
+        aria-expanded={this.state.isOpen}
       >
         {this.renderSelectButton()}
         {this.renderSelectPopup()}

--- a/src/components/Select/Select.jsx
+++ b/src/components/Select/Select.jsx
@@ -180,6 +180,24 @@ export default class Select extends React.Component {
   onClick = e => {
     e.stopPropagation();
     e.nativeEvent.stopImmediatePropagation();
+    if (this.props.isSplit && !this.props.disabled) {
+       this.onButtonClick(e);
+    }
+  };
+
+  onKeyUp = e => {
+    e.stopPropagation();
+    e.nativeEvent.stopImmediatePropagation();
+    if (this.props.isSplit && !this.props.disabled) {
+      const altPlusUp = e.altKey && ['Up', 'ArrowUp'].indexOf(e.key) >= 0;
+      const altPlusDown = e.altKey && ['Down', 'ArrowDown'].indexOf(e.key) >= 0;
+      const space = ['Space', ' '].indexOf(e.key) >= 0;
+      const enter = ['Enter'].indexOf(e.key) >= 0;
+      if (altPlusUp || altPlusDown || space || enter) {
+        e.preventDefault();
+        this.onButtonClick(e);
+      }
+    }
   };
 
   onButtonClick = () => {
@@ -542,8 +560,8 @@ export default class Select extends React.Component {
     return (
       <Wrapper
         role="button"
-        onClick={this.onClick}
-        onKeyUp={this.onClick}
+        onClick={(e) => this.onClick(e)}
+        onKeyUp={(e) => this.onKeyUp(e)}
         tabIndex={0}
         isSplit={isSplit}
         ref={selectNode => (this.selectNode = selectNode)}

--- a/src/components/Select/__snapshots__/Select.spec.js.snap
+++ b/src/components/Select/__snapshots__/Select.spec.js.snap
@@ -2,6 +2,8 @@
 
 exports[`jest-auto-snapshots > Select Matches snapshot when array prop "hotKeys" has one item: "[object Object]" 1`] = `
 <ForwardRef(styled.div)
+  aria-expanded={true}
+  aria-haspopup="true"
   data-tip=""
   fullWidth={true}
   isSplit={true}
@@ -57,6 +59,8 @@ exports[`jest-auto-snapshots > Select Matches snapshot when array prop "hotKeys"
 
 exports[`jest-auto-snapshots > Select Matches snapshot when array prop "hotKeys" is an empty array: "[]" 1`] = `
 <ForwardRef(styled.div)
+  aria-expanded={true}
+  aria-haspopup="true"
   data-tip=""
   fullWidth={true}
   isSplit={true}
@@ -112,6 +116,8 @@ exports[`jest-auto-snapshots > Select Matches snapshot when array prop "hotKeys"
 
 exports[`jest-auto-snapshots > Select Matches snapshot when array prop "items" has one item: "[object Object]" 1`] = `
 <ForwardRef(styled.div)
+  aria-expanded={true}
+  aria-haspopup="true"
   data-tip=""
   fullWidth={true}
   isSplit={true}
@@ -167,6 +173,8 @@ exports[`jest-auto-snapshots > Select Matches snapshot when array prop "items" h
 
 exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "capitalizeItemLabel" is set to: "false" 1`] = `
 <ForwardRef(styled.div)
+  aria-expanded={true}
+  aria-haspopup="true"
   data-tip=""
   fullWidth={true}
   isSplit={true}
@@ -222,6 +230,8 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "capita
 
 exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "disabled" is set to: "false" 1`] = `
 <ForwardRef(styled.div)
+  aria-expanded={true}
+  aria-haspopup="true"
   data-tip="jest-auto-snapshots String Fixture"
   fullWidth={true}
   isSplit={true}
@@ -278,6 +288,8 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "disabl
 
 exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "fullWidth" is set to: "false" 1`] = `
 <ForwardRef(styled.div)
+  aria-expanded={true}
+  aria-haspopup="true"
   data-tip=""
   fullWidth={false}
   isSplit={true}
@@ -333,6 +345,8 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "fullWi
 
 exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "hasCustomAction" is set to: "false" 1`] = `
 <ForwardRef(styled.div)
+  aria-expanded={true}
+  aria-haspopup="true"
   data-tip=""
   fullWidth={true}
   isSplit={true}
@@ -388,6 +402,8 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "hasCus
 
 exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "hasIconOnly" is set to: "false" 1`] = `
 <ForwardRef(styled.div)
+  aria-expanded={true}
+  aria-haspopup="true"
   data-tip=""
   fullWidth={true}
   isSplit={true}
@@ -443,6 +459,8 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "hasIco
 
 exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "hideSearch" is set to: "false" 1`] = `
 <ForwardRef(styled.div)
+  aria-expanded={true}
+  aria-haspopup="true"
   data-tip=""
   fullWidth={true}
   isSplit={true}
@@ -498,6 +516,8 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "hideSe
 
 exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "isInputSearch" is set to: "false" 1`] = `
 <ForwardRef(styled.div)
+  aria-expanded={true}
+  aria-haspopup="true"
   data-tip=""
   fullWidth={true}
   isSplit={true}
@@ -553,6 +573,8 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "isInpu
 
 exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "isOpen" is set to: "false" 1`] = `
 <ForwardRef(styled.div)
+  aria-expanded={false}
+  aria-haspopup="true"
   data-tip=""
   fullWidth={true}
   isSplit={true}
@@ -608,6 +630,8 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "isOpen
 
 exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "isSplit" is set to: "false" 1`] = `
 <ForwardRef(styled.div)
+  aria-expanded={true}
+  aria-haspopup="true"
   data-tip=""
   fullWidth={true}
   isSplit={false}
@@ -655,6 +679,8 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "isSpli
 
 exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "multiSelect" is set to: "false" 1`] = `
 <ForwardRef(styled.div)
+  aria-expanded={true}
+  aria-haspopup="true"
   data-tip=""
   fullWidth={true}
   isSplit={true}
@@ -710,6 +736,8 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "multiS
 
 exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "selectPopupVisible" is set to: "false" 1`] = `
 <ForwardRef(styled.div)
+  aria-expanded={true}
+  aria-haspopup="true"
   data-tip=""
   fullWidth={true}
   isSplit={true}
@@ -765,6 +793,8 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "select
 
 exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "shortcutsEnabled" is set to: "false" 1`] = `
 <ForwardRef(styled.div)
+  aria-expanded={true}
+  aria-haspopup="true"
   data-tip=""
   fullWidth={true}
   isSplit={true}
@@ -820,6 +850,8 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "shortc
 
 exports[`jest-auto-snapshots > Select Matches snapshot when passed all props 1`] = `
 <ForwardRef(styled.div)
+  aria-expanded={true}
+  aria-haspopup="true"
   data-tip=""
   fullWidth={true}
   isSplit={true}
@@ -875,6 +907,8 @@ exports[`jest-auto-snapshots > Select Matches snapshot when passed all props 1`]
 
 exports[`jest-auto-snapshots > Select Matches snapshot when passed only required props 1`] = `
 <ForwardRef(styled.div)
+  aria-expanded={false}
+  aria-haspopup="true"
   isSplit={false}
   onClick={[Function]}
   onKeyUp={[Function]}

--- a/src/components/Select/style.js
+++ b/src/components/Select/style.js
@@ -11,9 +11,9 @@ import {
 import { fontFamily } from '../style/fonts';
 
 export const Wrapper = styled.div`
-  outline: 0;
+  outline-style: none;
   :focus {
-    outline: 0;
+    outline-style: ${props => (props.isSplit ? 'auto' : '0')};
   }
   width: ${props => (props.isSplit || props.fullWidth ? '100%' : 'auto')};
   height: ${props => (props.isSplit ? '100%' : 'auto')};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adding aria attributes to select dropdown to make it more semantically accurate

<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Theres a subtle difference as a consequence of these changes, and that is that the split button now has more padding/spacing. You can see the difference in the attached screenshots, its just a few pixels difference. //cc: @letsbleachthis would you mind having a look at the screenshots at all please?

## Screenshots (if appropriate):
Before:
![image](https://user-images.githubusercontent.com/1383419/79985203-2b0c0d80-84a2-11ea-96d9-5c694775936b.png)

After:
![image](https://user-images.githubusercontent.com/1383419/79985169-1e87b500-84a2-11ea-9f0e-fc9f52c0a789.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style and guidelines of this project. <!--- Link to Standards file coming soon. -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the **CHANGELOG** document.
- [ ] I have added tests to cover my changes.
- [ ] I have performed a self-review of my own code
- [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] All new and existing tests passed.
- [ ] I have performed the accessibility audit of my UI changes according to the accessibility doc. <!--- Link to Accessibility Standards file coming soon. -->
- [ ] [Buffer Engineers] Someone from the Design team reviewed and approved my changes
- [ ] [Buffer Engineers] I have notified the BDS team of my changes in the #proj-design-system Slack channel
