### PR TITLE
add flex-shrink in select for when text overflows

### DIFF
--- a/src/components/Select/SelectItem/style.js
+++ b/src/components/Select/SelectItem/style.js
@@ -66,12 +66,11 @@ export const SelectItemCustom = styled.span`
 
 export const CheckIconWrapper = styled.span`
   margin-right: 8px;
-  display: inline-block;
   height: 16px;
   width: 16px;
   display: flex;
   justify-content: center;
-}
+  flex-shrink: 0;
 `;
 
 export const HotKeyPrompt = styled.span`

--- a/src/documentation/markdown/GettingStarted/Changelog.md
+++ b/src/documentation/markdown/GettingStarted/Changelog.md
@@ -1,4 +1,7 @@
 # Changelog
+## [5.34.6] - 2020-04-21
+- add flex-shrink in select for when text overflows
+
 ## [5.34.5] - 2020-04-13
 - aligns items in select
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When the select item text overflows, the icons are being shrunk down in size due to flexbox. Adding in flex-shrink 0 to ensure they keep their size