### PR TITLE
Allow select to reset even if searching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufferapp/ui-template",
-  "version": "5.37.2-beta.1525fc7",
+  "version": "5.37.2-beta.af07588",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufferapp/ui-template",
-  "version": "5.37.2",
+  "version": "5.37.2-beta.1525fc7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufferapp/ui-template",
-  "version": "5.37.2-beta.af07588",
+  "version": "5.37.2",
   "engines": {
     "node": ">=4.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufferapp/ui-template",
-  "version": "5.37.2",
+  "version": "5.37.2-beta.1525fc7",
   "engines": {
     "node": ">=4.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufferapp/ui-template",
-  "version": "5.37.2-beta.1525fc7",
+  "version": "5.37.2-beta.af07588",
   "engines": {
     "node": ">=4.0.0"
   },

--- a/src/components/Select/Select.jsx
+++ b/src/components/Select/Select.jsx
@@ -129,7 +129,7 @@ export default class Select extends React.Component {
       this.setState(
         {
           isOpen: false,
-          hoveredItem: undefined,
+          hoveredItem: undefined
         },
       );
     }
@@ -508,6 +508,7 @@ export default class Select extends React.Component {
               onChange={this.onSearchChange}
               placeholder={searchPlaceholder}
               isOpen={isOpen}
+              clearSearchOnBlur
             />
           </SearchBarWrapper>
         )}

--- a/src/components/Select/Select.jsx
+++ b/src/components/Select/Select.jsx
@@ -201,11 +201,12 @@ export default class Select extends React.Component {
   };
 
   onButtonClick = () => {
-    const { isOpen, items } = this.state;
-    const { isInputSearch } = this.props;
+    const { isOpen } = this.state;
+    const { isInputSearch, items } = this.props;
     this.setState(
       {
         isOpen: !isOpen,
+        items
       },
       () => {
         !isInputSearch && !isOpen && this.selectNode && this.selectNode.focus();

--- a/src/documentation/markdown/GettingStarted/Changelog.md
+++ b/src/documentation/markdown/GettingStarted/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [5.37.3] - 2020-06-01
+- Allow select to reset even if searching is interrupted 
+
 ## [5.37.2] - 2020-05-21
 - add flexibility for height and width in custom icons for Select 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We noticed that the Select wasn't resetting properly when the search was triggered: https://share.buffer.com/12uy2nye

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style and guidelines of this project. <!--- Link to Standards file coming soon. -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the **CHANGELOG** document.
- [ ] I have added tests to cover my changes.
- [ ] I have performed a self-review of my own code
- [x] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] All new and existing tests passed.
- [ ] I have performed the accessibility audit of my UI changes according to the accessibility doc. <!--- Link to Accessibility Standards file coming soon. -->
- [ ] [Buffer Engineers] Someone from the Design team reviewed and approved my changes
- [ ] [Buffer Engineers] I have notified the BDS team of my changes in the #proj-design-system Slack channel
