### PR TITLE
Remove unused `onClick` prop

### DIFF
--- a/src/components/NavBar/NavBarMenu/NavBarMenu.jsx
+++ b/src/components/NavBar/NavBarMenu/NavBarMenu.jsx
@@ -22,10 +22,10 @@ export function getUserAvatar(user) {
 /** NavBar Menu component used by the Select component to show a custom User name and avatar
  *  button */
 const NavBarMenu = props => {
-  const { user, onClick, isImpersonation } = props;
+  const { user, isImpersonation } = props;
 
   return (
-    <NavBarStyled onClick={onClick} {...props}>
+    <NavBarStyled {...props}>
       <NavBarUser>
         {isImpersonation && (
           <NavBarImpersonating
@@ -38,7 +38,7 @@ const NavBarMenu = props => {
         <NavBarName>{user.name}</NavBarName>
         <NavBarEmail>{user.email}</NavBarEmail>
       </NavBarUser>
-      <NavBarAvatar avatar={getUserAvatar(user)} onClick={onClick} />
+      <NavBarAvatar avatar={getUserAvatar(user)} />
       <NavBarChavron>
         <ChevronDown color="grayLight" size="large" />
       </NavBarChavron>
@@ -52,9 +52,6 @@ NavBarMenu.propTypes = {
     name: PropTypes.string.isRequired,
     email: PropTypes.string.isRequired,
   }).isRequired,
-
-  /** OnClick function to be called on Avatar click, passed by the Select component */
-  onClick: PropTypes.func.isRequired,
   isImpersonation: PropTypes.bool,
 };
 

--- a/src/components/NavBar/NavBarMenu/__snapshots__/NavBarMenu.spec.js.snap
+++ b/src/components/NavBar/NavBarMenu/__snapshots__/NavBarMenu.spec.js.snap
@@ -3,7 +3,6 @@
 exports[`jest-auto-snapshots > NavBarMenu Matches snapshot when boolean prop "isImpersonation" is set to: "false" 1`] = `
 <ForwardRef(styled.a)
   isImpersonation={false}
-  onClick={[MockFunction]}
   user={
     Object {
       "email": "jest-auto-snapshots String Fixture",
@@ -21,7 +20,6 @@ exports[`jest-auto-snapshots > NavBarMenu Matches snapshot when boolean prop "is
   </ForwardRef(styled.div)>
   <ForwardRef(styled.div)
     avatar="https://s3.amazonaws.com/buffer-ui/Default+Avatar.png"
-    onClick={[MockFunction]}
   />
   <ForwardRef(styled.div)>
     <ChevronDownIcon
@@ -35,7 +33,6 @@ exports[`jest-auto-snapshots > NavBarMenu Matches snapshot when boolean prop "is
 exports[`jest-auto-snapshots > NavBarMenu Matches snapshot when passed all props 1`] = `
 <ForwardRef(styled.a)
   isImpersonation={true}
-  onClick={[MockFunction]}
   user={
     Object {
       "email": "jest-auto-snapshots String Fixture",
@@ -64,7 +61,6 @@ exports[`jest-auto-snapshots > NavBarMenu Matches snapshot when passed all props
   </ForwardRef(styled.div)>
   <ForwardRef(styled.div)
     avatar="https://s3.amazonaws.com/buffer-ui/Default+Avatar.png"
-    onClick={[MockFunction]}
   />
   <ForwardRef(styled.div)>
     <ChevronDownIcon
@@ -78,7 +74,6 @@ exports[`jest-auto-snapshots > NavBarMenu Matches snapshot when passed all props
 exports[`jest-auto-snapshots > NavBarMenu Matches snapshot when passed only required props 1`] = `
 <ForwardRef(styled.a)
   isImpersonation={false}
-  onClick={[MockFunction]}
   user={
     Object {
       "email": "jest-auto-snapshots String Fixture",
@@ -96,7 +91,6 @@ exports[`jest-auto-snapshots > NavBarMenu Matches snapshot when passed only requ
   </ForwardRef(styled.div)>
   <ForwardRef(styled.div)
     avatar="https://s3.amazonaws.com/buffer-ui/Default+Avatar.png"
-    onClick={[MockFunction]}
   />
   <ForwardRef(styled.div)>
     <ChevronDownIcon


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Due to previous changes with the higher level `DropdownMenu` component we no longer need an onClick here.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style and guidelines of this project. <!--- Link to Standards file coming soon. -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated the **CHANGELOG** document.
- [x] I have added tests to cover my changes.
- [x] I have performed a self-review of my own code
- [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] All new and existing tests passed.
- [ ] I have performed the accessibility audit of my UI changes according to the accessibility doc. <!--- Link to Accessibility Standards file coming soon. -->
- [ ] [Buffer Engineers] Someone from the Design team reviewed and approved my changes
- [ ] [Buffer Engineers] I have notified the BDS team of my changes in the #proj-design-system Slack channel