### PR TITLE
Stop building the project as a CommonJS library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufferapp/ui-template",
-  "version": "5.48.2",
+  "version": "5.48.2-beta.df91dcb",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@bufferapp/ui-template",
-  "version": "5.48.2",
+  "version": "5.48.2-beta.28efde8",
+  "sideEffects": false,
   "engines": {
     "node": ">=4.0.0"
   },
@@ -148,9 +149,9 @@
     "predeploy:docs": "npm run gen:docs && npm run build:docs",
     "deploy:docs": "gh-pages -d build",
     "prebuild:lib": "rimraf lib",
-    "build:lib": "npm-run-all --parallel build:commonjs build:copy-files",
+    "build:lib": "npm-run-all --parallel build:esm build:copy-files",
     "build:copy-files": "node scripts/copyBuildFiles.js",
-    "build:commonjs": "cross-env NODE_ENV=production babel ./src/components --out-dir ./lib --ignore index.js",
+    "build:esm": "cross-env NODE_ENV=production babel ./src/components --out-dir ./lib --ignore index.js",
     "publish": "./scripts/publish.sh",
     "beta:publish": "node ./scripts/betaPublish.js",
     "component:new": "node ./scripts/newComponent.js",
@@ -186,13 +187,15 @@
     }
   },
   "babel": {
-    "plugins": [
-      "@babel/plugin-transform-modules-commonjs",
-      "@babel/plugin-proposal-class-properties",
-      "@babel/plugin-proposal-export-default-from"
-    ],
     "presets": [
-      "@babel/preset-env",
+      [
+        "@babel/preset-env",
+        {
+          "targets": {
+            "esmodules": true
+          }
+        }
+      ],
       "@babel/react"
     ]
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufferapp/ui-template",
-  "version": "5.48.2-beta.28efde8",
+  "version": "5.48.2-beta.df91dcb",
   "sideEffects": false,
   "engines": {
     "node": ">=4.0.0"
@@ -187,6 +187,10 @@
     }
   },
   "babel": {
+    "plugins": [
+      "@babel/plugin-proposal-class-properties",
+      "@babel/plugin-proposal-export-default-from"
+    ],
     "presets": [
       [
         "@babel/preset-env",

--- a/src/components/Avatar/Avatar.jsx
+++ b/src/components/Avatar/Avatar.jsx
@@ -6,7 +6,12 @@ import styled from 'styled-components';
 import * as Styles from './style';
 // import { socialNetworks } from '../constants';
 import { facebook, googleplus, instagram, linkedin, pinterest, twitter } from '../style/colors';
-import { Instagram, Facebook, Twitter, LinkedIn, Pinterest, GooglePlus } from '../Icon';
+import Instagram from '../Icon/Icons/Instagram'
+import Facebook from '../Icon/Icons/Facebook'
+import Twitter from '../Icon/Icons/Twitter'
+import LinkedIn from '../Icon/Icons/LinkedIn'
+import Pinterest from '../Icon/Icons/Pinterest'
+import GooglePlus from '../Icon/Icons/GooglePlus'
 
 const Wrapper = styled.div`
   ${props => Styles.wrapper[props.size]}

--- a/src/components/DropdownMenu/ButtonItem/ButtonItem.jsx
+++ b/src/components/DropdownMenu/ButtonItem/ButtonItem.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { ButtonItemStyled, ButtonLabel } from '../style';
-import { Checkmark as CheckmarkIcon } from '../../Icon';
+import CheckmarkIcon from '../../Icon/Icons/Checkmark'
 import { green } from '../../style/colors';
 import { keyCode } from '../keyCode';
 

--- a/src/components/Input/Input.jsx
+++ b/src/components/Input/Input.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import PropTypes from 'prop-types';
 import * as Styles from './style';
-import { Warning } from '../Icon';
+import Warning from '../Icon/Icons/Warning';
 import Text from '../Text';
 
 export default class Input extends React.Component {

--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import * as Styles from './style';
 import Button from '../Button';
-import { Cross } from '../Icon';
+import Cross from '../Icon/Icons/Cross';
 
 function setCookie(cookie, cookieKey, days, value) {
   const expiresInDays = days * 24 * 60 * 60;

--- a/src/components/NavBar/NavBar.jsx
+++ b/src/components/NavBar/NavBar.jsx
@@ -1,17 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import {
-  Cross,
-  Info as InfoIcon,
-  ArrowLeft,
-  Person as PersonIcon,
-  Instagram as InstagramIcon,
-  Twitter as TwitterIcon,
-  Facebook as FacebookIcon,
-  Pinterest as PinterestIcon,
-  LinkedIn as LinkedInIcon,
-} from '../Icon';
+import Cross from '../Icon/Icons/Cross'
+import InfoIcon from '../Icon/Icons/Info'
+import ArrowLeft from '../Icon/Icons/ArrowLeft'
+import PersonIcon from '../Icon/Icons/Person'
+import InstagramIcon from '../Icon/Icons/Instagram'
+import TwitterIcon from '../Icon/Icons/Twitter'
+import FacebookIcon from '../Icon/Icons/Facebook'
+import PinterestIcon from '../Icon/Icons/Pinterest'
+import LinkedInIcon from '../Icon/Icons/LinkedIn'
 
 import {
   gray,
@@ -195,7 +193,7 @@ export function appendOrgSwitcher(orgSwitcher) {
     if (!item.subItems || item.subItems.length === 0) {
       item.defaultTooltipMessage = 'No social accounts connected yet.';
     }
-    
+
     return item;
   });
 }

--- a/src/components/NavBar/NavBarMenu/NavBarMenu.jsx
+++ b/src/components/NavBar/NavBarMenu/NavBarMenu.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { ChevronDown } from '../../Icon';
+import ChevronDown from '../../Icon/Icons/ChevronDown';
 import {
   NavBarStyled,
   NavBarEmail,

--- a/src/components/Select/SelectItem/SelectItem.jsx
+++ b/src/components/Select/SelectItem/SelectItem.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Checkmark } from '../../Icon';
+import Checkmark from '../../Icon/Icons/Checkmark'
 import {
   SelectItemStyled,
   SelectItemLabel,

--- a/src/components/SocialButton/SocialButton.jsx
+++ b/src/components/SocialButton/SocialButton.jsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Twitter, Instagram, Facebook, Pinterest, LinkedIn } from '../Icon';
+import Instagram from '../Icon/Icons/Instagram'
+import Facebook from '../Icon/Icons/Facebook'
+import Twitter from '../Icon/Icons/Twitter'
+import LinkedIn from '../Icon/Icons/LinkedIn'
+import Pinterest from '../Icon/Icons/Pinterest'
 import Text from '../Text/Text';
 
 import {

--- a/src/components/TextArea/TextArea.jsx
+++ b/src/components/TextArea/TextArea.jsx
@@ -2,23 +2,23 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Text from '../Text';
 import {HelpTextWrapper, HelpText} from '../Input/style';
-import { Warning } from '../Icon';
+import Warning from '../Icon/Icons/Warning';
 import {Container, StyledTextArea} from './style';
 
 export default class TextArea extends React.Component {
   render() {
     const {
-      value, 
-      label, 
-      hasError, 
-      help, 
-      disabled, 
-      rows, 
-      onChange, 
-      id, 
+      value,
+      label,
+      hasError,
+      help,
+      disabled,
+      rows,
+      onChange,
+      id,
       fullHeight,
-      forwardRef, 
-      ...props 
+      forwardRef,
+      ...props
     } = this.props;
     return (
       <Container>
@@ -69,12 +69,12 @@ TextArea.propTypes = {
   id: PropTypes.string.isRequired,
   /** If the textarea should take the height of the parent div */
   fullHeight: PropTypes.bool,
-  /** 
+  /**
    * this consumed by the default export that is wrapping the component into a ForwardRef
    * @ignore
    */
   forwardRef: PropTypes.oneOfType([
-    PropTypes.func, 
+    PropTypes.func,
     PropTypes.shape({ current: PropTypes.instanceOf(Element) })
   ]),
 };

--- a/src/documentation/app/layout/sidebar/Sidebar.jsx
+++ b/src/documentation/app/layout/sidebar/Sidebar.jsx
@@ -3,7 +3,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
-import { ChevronDown, ChevronUp } from '@bufferapp/ui/Icon';
+import ChevronDown from '@bufferapp/ui/Icon/Icons/ChevronDown';
+import ChevronUp from '@bufferapp/ui/Icon/Icons/ChevronUp';
 import helper from 'immutability-helper';
 
 const SidebarWrapper = styled.div`

--- a/src/documentation/examples/AppShell/AppShell.jsx
+++ b/src/documentation/examples/AppShell/AppShell.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import AppShell from '@bufferapp/ui/AppShell';
-import { Gear } from '@bufferapp/ui/Icon';
+import Gear from '@bufferapp/ui/Icon/Icons/Gear';
 
 import { gray } from '@bufferapp/ui/style/colors';
 

--- a/src/documentation/examples/AppShell/WithEngageEnabled.jsx
+++ b/src/documentation/examples/AppShell/WithEngageEnabled.jsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import AppShell from '@bufferapp/ui/AppShell';
-import {
-  Gear,
-} from '@bufferapp/ui/Icon';
+import Gear from '@bufferapp/ui/Icon/Icons/Gear';
 
 import { gray } from '@bufferapp/ui/style/colors';
 

--- a/src/documentation/examples/AppShell/WithImpersonationSession.jsx
+++ b/src/documentation/examples/AppShell/WithImpersonationSession.jsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import AppShell from '@bufferapp/ui/AppShell';
-import {
-  Gear,
-} from '@bufferapp/ui/Icon';
+import Gear from '@bufferapp/ui/Icon/Icons/Gear';
 
 import { gray } from '@bufferapp/ui/style/colors';
 

--- a/src/documentation/examples/AppShell/WithOrgSwitcher.jsx
+++ b/src/documentation/examples/AppShell/WithOrgSwitcher.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import AppShell from '@bufferapp/ui/AppShell';
-import { Gear } from '@bufferapp/ui/Icon';
+import Gear from '@bufferapp/ui/Icon/Icons/Gear';
 
 import { gray } from '@bufferapp/ui/style/colors';
 

--- a/src/documentation/examples/Button/Type/TypeIcon.jsx
+++ b/src/documentation/examples/Button/Type/TypeIcon.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Button from '@bufferapp/ui/Button';
-import { Folder } from '@bufferapp/ui/Icon';
+import Folder from '@bufferapp/ui/Icon/Icons/Folder';
 
 /** Secondary Icon */
 export default function ExampleButton() {

--- a/src/documentation/examples/Button/Type/TypeIconEnd.jsx
+++ b/src/documentation/examples/Button/Type/TypeIconEnd.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Button from '@bufferapp/ui/Button';
-import { Folder } from '@bufferapp/ui/Icon';
+import Folder from '@bufferapp/ui/Icon/Icons/Folder';
 
 /** Secondary with Icon at End */
 export default function ExampleButton() {

--- a/src/documentation/examples/Button/Type/TypePrimaryIcon.jsx
+++ b/src/documentation/examples/Button/Type/TypePrimaryIcon.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Button from '@bufferapp/ui/Button';
-import { Message } from '@bufferapp/ui/Icon';
+import Message from '@bufferapp/ui/Icon/Icons/Message';
 
 /** Primary with Icon */
 export default function ExampleButton() {

--- a/src/documentation/examples/Button/Type/TypePrimaryIconEnd.jsx
+++ b/src/documentation/examples/Button/Type/TypePrimaryIconEnd.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Button from '@bufferapp/ui/Button';
-import { Message } from '@bufferapp/ui/Icon';
+import Message from '@bufferapp/ui/Icon/Icons/Message';
 
 /** Primary with Icon */
 export default function ExampleButton() {

--- a/src/documentation/examples/Button/Type/TypeSecondaryIcon.jsx
+++ b/src/documentation/examples/Button/Type/TypeSecondaryIcon.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Button from '@bufferapp/ui/Button';
-import { Folder } from '@bufferapp/ui/Icon';
+import Folder from '@bufferapp/ui/Icon/Icons/Folder';
 
 /** Secondary with Icon */
 export default function ExampleButton() {

--- a/src/documentation/examples/Select/SelectWithIcon.jsx
+++ b/src/documentation/examples/Select/SelectWithIcon.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import Select from '@bufferapp/ui/Select';
-import { Person } from '@bufferapp/ui/Icon';
-
+import Person from '@bufferapp/ui/Icon/Icons/Person';
 
 /** With Icon */
 export default function ExampleSelect() {

--- a/src/documentation/examples/Select/SelectWithInputSearch.jsx
+++ b/src/documentation/examples/Select/SelectWithInputSearch.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Select from '@bufferapp/ui/Select';
 import Search from '@bufferapp/ui/Search';
-import { Search as SearchIcon } from '@bufferapp/ui/Icon';
+import SearchIcon from '@bufferapp/ui/Icon/Icons/Search';
 
 const searchBarWrapperStyle = {
   width: '100%',

--- a/src/documentation/examples/Select/SelectWithMenuAndCustomItem.jsx
+++ b/src/documentation/examples/Select/SelectWithMenuAndCustomItem.jsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import Select from '@bufferapp/ui/Select';
-import { Person, People, Gear, ArrowLeft } from '@bufferapp/ui/Icon';
+import Person from '@bufferapp/ui/Icon/Icons/Person'
+import People from '@bufferapp/ui/Icon/Icons/People'
+import Gear from '@bufferapp/ui/Icon/Icons/Gear'
+import ArrowLeft from '@bufferapp/ui/Icon/Icons/ArrowLeft'
 import { NavBarMenu } from '@bufferapp/ui/NavBar';
 
 /** With Custom Component and Custom Items */

--- a/src/documentation/examples/Select/SelectWithSearch.jsx
+++ b/src/documentation/examples/Select/SelectWithSearch.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Select from '@bufferapp/ui/Select';
-import { Flag } from '@bufferapp/ui/Icon';
+import Flag from '@bufferapp/ui/Icon/Icons/Flag';
 
 /** With Search */
 export default function ExampleSelectWithSearch() {

--- a/src/documentation/examples/SidebarListItem/SidebarListItem.jsx
+++ b/src/documentation/examples/SidebarListItem/SidebarListItem.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import SidebarListItem from '@bufferapp/ui/SidebarListItem';
-import { Person } from '@bufferapp/ui/Icon';
+import Person from '@bufferapp/ui/Icon/Icons/Person';
 
 /** SidebarListItem Example */
 export default function ExampleSidebarListItem() {

--- a/src/documentation/examples/SidebarListItem/SidebarListItemSelected.jsx
+++ b/src/documentation/examples/SidebarListItem/SidebarListItemSelected.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import SidebarListItem from '@bufferapp/ui/SidebarListItem';
-import { Person } from '@bufferapp/ui/Icon';
+import Person from '@bufferapp/ui/Icon/Icons/Person';
 
 /** SidebarListItem Selected Example */
 export default function ExampleSidebarListItem() {

--- a/src/documentation/examples/SidebarListItem/SidebarListItemWithIcon.jsx
+++ b/src/documentation/examples/SidebarListItem/SidebarListItemWithIcon.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import SidebarListItem from '@bufferapp/ui/SidebarListItem';
-import { Warning } from '@bufferapp/ui/Icon';
+import Warning from '@bufferapp/ui/Icon/Icons/Warning'
 
 /** SidebarListItem With Badge Icon Example */
 export default function ExampleSidebarListItem() {


### PR DESCRIPTION
## Description

To stop building @bufferapp/ui as a CommonJS library and instead just build it with ES Modules in mind. In the end, bundling and browser support will be handled by the different webpack builds in our frontends, and the CommonJS step is preventing us from doing tree shaking based on what we use this library for on each product.

## Testing steps

I'd love for you all to test this in your frontends and report back here if there are any bugs or improvements we can make before shipping this. Here are my recommended steps for testing it:

### Checking the current production bundle size with your latest @bufferapp/ui

#### Install webpack bundle analyzer

If you don't have `webpack-bundle-analyzer`, install it as a dev dependency in your project root:

`yarn install -DW webpack-bundle-analyzer`

Instead of tweaking our build step so that webpack-bundle-analyzer always yields its results, create a new script in your `package.json` that runs that analysis for your prod build. Something like:

`"analyze:prod": "<your production build command> && webpack-bundle-analyzer --port 8082 build/stats.json"`

...and tweak your webpack config so that you include webpack-bundle-analyzer as a plugin on your plugin list

```js
{
  plugins: [
    // other plugins
    new BundleAnalyzerPlugin({
      analyzerMode: 'disabled',
      generateStatsFile: true,
      statsOptions: {
        source: false,
      },
    }),
}
```

This will generate a `stats.json` file every time you run webpack, and the `analyze:prod` command will trigger the client to read those stats.

#### Run this analysis and check your @bufferapp/ui bundled size

Now, if everything is set up correctly, you should be able to run `yarn run analyze:prod` (or `npm run analyze:prod`) and it will open `http://127.0.0.1:8082/` with something like this:

<img width="1273" alt="CleanShot 2020-10-21 at 12 33 13@2x" src="https://user-images.githubusercontent.com/720667/96708501-9e330580-1399-11eb-8258-cc798029f0aa.png">

In this case, Engage's production bundle has 200KB included (47KB gzipped).

Let's see if we can make it smaller than that!

### Reducing bundle size and testing it again

Install this beta version of the UI library: `5.48.2-beta.df91dcb`.

#### Set up your build process for tree shaking

You need to set `"sideEffects": false` in your package.json (you might need to do it on all your `package.json` file if you're using yarn workspaces) and `usedExports: true` in your webpack config under the `optimization` settings.

Also, it's important you make sure you're not importing Icons with calls such as `import * as icons from '@bufferapp/ui/Icon'`, since that'll prevent webpack from tree shaking the icons you're not using.

**Using imports such as `import { ChevronUp } from '@bufferapp/ui/Icon'` shouldn't cause issues, but it seems like it is still importing it all, this is something that we need to look into whether it's a build issue on our projects or in the library, or both.**

#### Testing it again

Running `analyze:prod` again after these changes yields these results:

<img width="1265" alt="CleanShot 2020-10-21 at 12 43 47@2x" src="https://user-images.githubusercontent.com/720667/96709916-a2f8b900-139b-11eb-820f-2eb82b8ed0b6.png">

@bufferapp/ui is now just 106KB parsed / 26.06 KB gzipped!

**This is a 47% filesize reduction, and 10% overall vendor bundle reduction for Engage!**

## Action items

Try the following steps in Account / Analyze / Engage / Publish:

- [ ] Measure bundle size before any changes.
- [ ] Implement tree shaking and install this beta version for @bufferapp/ui `5.48.2-beta.df91dcb`.
- [ ] Measure bundle size after any changes.
- [ ] Test that staging works still in the same way.

...and report back here how things are looking!

## Links

https://github.com/bufferapp/buffer-engage-client/compare/test/reduce-ui-bundle-size?expand=1 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style and guidelines of this project. <!--- Link to Standards file coming soon. -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the **CHANGELOG** document.
- [ ] I have added tests to cover my changes.
- [ ] I have performed a self-review of my own code
- [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] All new and existing tests passed.
- [ ] I have performed the accessibility audit of my UI changes according to the accessibility doc. <!--- Link to Accessibility Standards file coming soon. -->
- [ ] [Buffer Engineers] Someone from the Design team reviewed and approved my changes
- [ ] [Buffer Engineers] I have notified the BDS team of my changes in the #proj-design-system Slack channel
