### PR TITLE
[UI-247] Add a danger style variation for buttons

### DIFF
--- a/src/components/Button/Button.jsx
+++ b/src/components/Button/Button.jsx
@@ -85,6 +85,7 @@ const Button = ({
       disabled={disabled}
       type={type}
       fullWidth={fullWidth}
+      loading={loading}
     >
       <ButtonContainerStyled>
         <ButtonStyled

--- a/src/components/Button/Button.jsx
+++ b/src/components/Button/Button.jsx
@@ -155,7 +155,14 @@ Button.propTypes = {
   label: PropTypes.string,
 
   /** Type of button */
-  type: PropTypes.oneOf(['link', 'primary', 'secondary', 'text', 'error']),
+  type: PropTypes.oneOf([
+    'link',
+    'primary',
+    'secondary',
+    'text',
+    'error',
+    'danger',
+  ]),
 
   /** Is the Button Split  */
   isSplit: PropTypes.bool,

--- a/src/components/Button/Button.jsx
+++ b/src/components/Button/Button.jsx
@@ -18,7 +18,6 @@ export const ButtonWrapperStyled = styled.div`
 
 export const ButtonContainerStyled = styled.div`
   ${Styles.ButtonContainerBase};
-  
 `;
 
 export const ButtonStyled = styled.button`

--- a/src/components/Button/__snapshots__/Button.spec.js.snap
+++ b/src/components/Button/__snapshots__/Button.spec.js.snap
@@ -5,6 +5,7 @@ exports[`jest-auto-snapshots > Button Matches snapshot when array prop "items" h
   className="jest-auto-snapshots String Fixture"
   disabled={true}
   fullWidth={true}
+  loading={true}
   type="link"
 >
   <ForwardRef(styled.div)>
@@ -36,6 +37,7 @@ exports[`jest-auto-snapshots > Button Matches snapshot when array prop "items" i
   className="jest-auto-snapshots String Fixture"
   disabled={true}
   fullWidth={true}
+  loading={true}
   type="link"
 >
   <ForwardRef(styled.div)>
@@ -67,6 +69,7 @@ exports[`jest-auto-snapshots > Button Matches snapshot when boolean prop "disabl
   className="jest-auto-snapshots String Fixture"
   disabled={false}
   fullWidth={true}
+  loading={true}
   type="link"
 >
   <ForwardRef(styled.div)>
@@ -99,6 +102,7 @@ exports[`jest-auto-snapshots > Button Matches snapshot when boolean prop "fullWi
   className="jest-auto-snapshots String Fixture"
   disabled={true}
   fullWidth={false}
+  loading={true}
   type="link"
 >
   <ForwardRef(styled.div)>
@@ -130,6 +134,7 @@ exports[`jest-auto-snapshots > Button Matches snapshot when boolean prop "hasIco
   className="jest-auto-snapshots String Fixture"
   disabled={true}
   fullWidth={true}
+  loading={true}
   type="link"
 >
   <ForwardRef(styled.div)>
@@ -164,6 +169,7 @@ exports[`jest-auto-snapshots > Button Matches snapshot when boolean prop "hideSe
   className="jest-auto-snapshots String Fixture"
   disabled={true}
   fullWidth={true}
+  loading={true}
   type="link"
 >
   <ForwardRef(styled.div)>
@@ -195,6 +201,7 @@ exports[`jest-auto-snapshots > Button Matches snapshot when boolean prop "iconEn
   className="jest-auto-snapshots String Fixture"
   disabled={true}
   fullWidth={true}
+  loading={true}
   type="link"
 >
   <ForwardRef(styled.div)>
@@ -226,6 +233,7 @@ exports[`jest-auto-snapshots > Button Matches snapshot when boolean prop "isSele
   className="jest-auto-snapshots String Fixture"
   disabled={true}
   fullWidth={true}
+  loading={true}
   type="link"
 >
   <ForwardRef(styled.div)>
@@ -257,6 +265,7 @@ exports[`jest-auto-snapshots > Button Matches snapshot when boolean prop "isSpli
   className="jest-auto-snapshots String Fixture"
   disabled={true}
   fullWidth={true}
+  loading={true}
   type="link"
 >
   <ForwardRef(styled.div)>
@@ -288,6 +297,7 @@ exports[`jest-auto-snapshots > Button Matches snapshot when boolean prop "loadin
   className="jest-auto-snapshots String Fixture"
   disabled={true}
   fullWidth={true}
+  loading={false}
   type="link"
 >
   <ForwardRef(styled.div)>
@@ -315,6 +325,7 @@ exports[`jest-auto-snapshots > Button Matches snapshot when passed all props 1`]
   className="jest-auto-snapshots String Fixture"
   disabled={true}
   fullWidth={true}
+  loading={true}
   type="link"
 >
   <ForwardRef(styled.div)>
@@ -345,6 +356,7 @@ exports[`jest-auto-snapshots > Button Matches snapshot when passed only required
 <ForwardRef(styled.div)
   disabled={false}
   fullWidth={false}
+  loading={false}
   type="secondary"
 >
   <ForwardRef(styled.div)>

--- a/src/components/Button/style.js
+++ b/src/components/Button/style.js
@@ -12,6 +12,9 @@ import {
   boxShadow,
   grayLight,
   orangeDark,
+  redDark,
+  redDarker,
+  redLighter,
   orange as orangeColor,
 } from '../style/colors';
 import {
@@ -156,6 +159,22 @@ export const secondary = css`
     color: ${grayDarker};
   }
 `;
+
+export const danger = css`
+  background-color: ${props => (props.loading ? redDarker : redDark)};
+  color: ${white};
+  border-color: ${redDarker};
+
+  :hover {
+    background-color: ${redDarker};
+  }
+
+  :focus {
+    box-shadow: 0 0 0 3px ${redLighter};
+    background-color: ${redDark};
+  }
+`;
+
 export const link = css`
   background-color: transparent;
   color: ${blue};

--- a/src/components/Button/style.js
+++ b/src/components/Button/style.js
@@ -65,7 +65,6 @@ export const ButtonWrapperBase = css`
   }
 `;
 
-
 export const ButtonContainerBase = css`
   -webkit-appearance: none;
   align-items: center;
@@ -144,6 +143,7 @@ export const primary = css`
     color: ${white};
   }
 `;
+
 export const secondary = css`
   background-color: ${white};
   color: ${grayDark};

--- a/src/components/style/colors.js
+++ b/src/components/style/colors.js
@@ -9,6 +9,7 @@ export const pinkLighter = '#F0A8DE';
 export const teal = '#00C8CF';
 export const red = '#E0364F';
 export const redDark = '#9D2637';
+export const redDarker = '#5A1620';
 export const redLight = '#E97284';
 export const redLighter = '#F3AFB9';
 export const orange = '#FF702C';

--- a/src/documentation/examples/Button/Type/TypeDanger.jsx
+++ b/src/documentation/examples/Button/Type/TypeDanger.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import Button from '@bufferapp/ui/Button';
+
+/** Danger */
+export default function ExampleTypeDanger() {
+  return <Button type="danger" onClick={() => {}} label="Click Me" />;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- Adds styles for a button type variation for danger (actions that are destructive)
- Passes down a `danger` prop type to adjust styles
- Passes down a `loading` prop in order to adjust styles based on if the state is loading
- Adds a danger button to the documentation

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Adds a danger style variation for buttons that involve a destructive action.

Task from Frontend Board: https://github.com/bufferapp/ui/issues/247
Figma design: https://www.figma.com/file/MgtrTHwQOczkZIhHmxVQ4lEN/BDS-Buttons?node-id=415%3A493

## Screenshots (if appropriate):

**Active**

<img width="582" alt="Screen Shot 2020-10-26 at 12 05 45 PM" src="https://user-images.githubusercontent.com/10112294/97197264-d1074000-1783-11eb-8b56-236cbfde24e1.png">


**Focus**

<img width="579" alt="Screen Shot 2020-10-26 at 12 05 54 PM" src="https://user-images.githubusercontent.com/10112294/97197252-ccdb2280-1783-11eb-9fab-cbc173bb64e1.png">


**Loading**

![Screen Recording 2020-10-26 at 12 11 PM](https://user-images.githubusercontent.com/10112294/97197794-6c98b080-1784-11eb-952a-9fb89e0a06f2.gif)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style and guidelines of this project. <!--- Link to Standards file coming soon. -->
- [ ] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [ ] I have updated the **CHANGELOG** document.
- [ ] I have added tests to cover my changes.
- [x] I have performed a self-review of my own code
- [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] All new and existing tests passed.
- [ ] I have performed the accessibility audit of my UI changes according to the accessibility doc. <!--- Link to Accessibility Standards file coming soon. -->
- [ ] [Buffer Engineers] Someone from the Design team reviewed and approved my changes
- [ ] [Buffer Engineers] I have notified the BDS team of my changes in the #proj-design-system Slack channel
