### PR TITLE
Allow hiding channels tooltip for org switcher

### DIFF
--- a/src/components/NavBar/NavBar.jsx
+++ b/src/components/NavBar/NavBar.jsx
@@ -194,8 +194,8 @@ export function appendOrgSwitcher(orgSwitcher) {
     }
 
     if (item.hideTooltip) {
-      // Allows the ability to hide channels, for example: hiding channels
-      // until we have released shared channels
+      // Allows the ability to hide channels related tooltips, for example:
+      // hiding channels or message until we have released shared channels
       item.defaultTooltipMessage = '';
     } else if (!item.subItems || item.subItems.length === 0) {
       item.defaultTooltipMessage = 'No channels connected yet.';

--- a/src/components/NavBar/NavBar.jsx
+++ b/src/components/NavBar/NavBar.jsx
@@ -192,10 +192,15 @@ export function appendOrgSwitcher(orgSwitcher) {
         subItem.icon = getNetworkIcon(subItem);
       });
     }
-    if (!item.subItems || item.subItems.length === 0) {
+
+    if (item.hideTooltip) {
+      // Allows the ability to hide channels, for example: hiding channels
+      // until we have released shared channels
+      item.defaultTooltipMessage = '';
+    } else if (!item.subItems || item.subItems.length === 0) {
       item.defaultTooltipMessage = 'No channels connected yet.';
     }
-    
+
     return item;
   });
 }
@@ -245,12 +250,12 @@ class NavBar extends React.Component {
               xPosition="right"
               ariaLabel="Help Menu"
               ariaLabelPopup="Help"
-              menubarItem={(
+              menubarItem={
                 <NavBarHelp>
                   <InfoIcon />
                   <NavBarHelpText>Help</NavBarHelpText>
                 </NavBarHelp>
-              )}
+              }
               items={helpMenuItems}
             />
           )}

--- a/src/components/NavBar/NavBar.jsx
+++ b/src/components/NavBar/NavBar.jsx
@@ -250,12 +250,12 @@ class NavBar extends React.Component {
               xPosition="right"
               ariaLabel="Help Menu"
               ariaLabelPopup="Help"
-              menubarItem={
+              menubarItem={(
                 <NavBarHelp>
                   <InfoIcon />
                   <NavBarHelpText>Help</NavBarHelpText>
                 </NavBarHelp>
-              }
+              )}
               items={helpMenuItems}
             />
           )}

--- a/src/documentation/markdown/GettingStarted/CHANGELOG.md
+++ b/src/documentation/markdown/GettingStarted/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [5.53.2] - 2020-11-18
+- Adds the ability to hide channels tooltip in the org switcher
+
 ## [5.53.0] - 2020-11-17
 - Adds new icons - Audience, Day, Frequency and Post
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->



## Description
<!--- Describe your changes in detail -->

Allows subItems for the org switcher to include a `hideTooltip` property in order to hide tool tips (channels info) when a user hovers over that organization in the org switcher. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The org switcher provides a list of channels associated with an organization when a user hovers over that organization. If no channels have been connected yet, then it defaults to a tooltip message that reads, `No channels connected yet.`. For the global org switcher, we do not yet have shared channels in place so we need a way to hide these tooltips for now. 

## Screenshots (if appropriate):

**Before:**

![Screen Recording 2020-11-18 at 07 42 AM](https://user-images.githubusercontent.com/10112294/99532078-bc2c5f80-2971-11eb-9ed8-2e34cc8c6f27.gif)


**After:**
![Screen Recording 2020-11-18 at 07 22 AM](https://user-images.githubusercontent.com/10112294/99531882-68ba1180-2971-11eb-8387-bbc6641ae39e.gif)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style and guidelines of this project. <!--- Link to Standards file coming soon. -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the **CHANGELOG** document.
- [ ] I have added tests to cover my changes.
- [x] I have performed a self-review of my own code
- [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] All new and existing tests passed.
- [ ] I have performed the accessibility audit of my UI changes according to the accessibility doc. <!--- Link to Accessibility Standards file coming soon. -->
- [ ] [Buffer Engineers] Someone from the Design team reviewed and approved my changes
- [x] [Buffer Engineers] I have notified the BDS team of my changes in the #proj-design-system Slack channel
