### PR TITLE
Add font weight variants to Link component

### DIFF
--- a/src/components/Link/Link.jsx
+++ b/src/components/Link/Link.jsx
@@ -2,8 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { LinkStyled } from './style';
+import { fontWeightMedium } from '../style/fonts';
 
-const Link = ({ children, href, newTab, download, className, title }) => (
+const Link = ({ children, href, newTab, download, className, title, fontWeight }) => (
   <LinkStyled
     href={href}
     target={newTab ? '_blank' : '_self'}
@@ -11,6 +12,7 @@ const Link = ({ children, href, newTab, download, className, title }) => (
     download={download}
     className={className}
     title={title}
+    fontWeight={fontWeight}
   >
     {children}
   </LinkStyled>
@@ -29,6 +31,8 @@ Link.propTypes = {
   className: PropTypes.string,
   /** Title of the link. */
   title: PropTypes.string,
+  /** Font weight of the link. */
+  fontWeight: PropTypes.oneOf([500, 700]),
 };
 
 Link.defaultProps = {
@@ -36,6 +40,7 @@ Link.defaultProps = {
   download: false,
   className: undefined,
   title: '',
+  fontWeight: fontWeightMedium,
 };
 
 export default Link;

--- a/src/components/Link/__snapshots__/Link.spec.js.snap
+++ b/src/components/Link/__snapshots__/Link.spec.js.snap
@@ -4,6 +4,7 @@ exports[`jest-auto-snapshots > Link Matches snapshot when boolean prop "download
 <ForwardRef(styled.a)
   className="jest-auto-snapshots String Fixture"
   download={false}
+  fontWeight="0"
   href="jest-auto-snapshots String Fixture"
   rel="noopener noreferrer"
   target="_blank"
@@ -17,6 +18,7 @@ exports[`jest-auto-snapshots > Link Matches snapshot when boolean prop "newTab" 
 <ForwardRef(styled.a)
   className="jest-auto-snapshots String Fixture"
   download={true}
+  fontWeight="0"
   href="jest-auto-snapshots String Fixture"
   target="_self"
   title="jest-auto-snapshots String Fixture"
@@ -29,6 +31,7 @@ exports[`jest-auto-snapshots > Link Matches snapshot when passed all props 1`] =
 <ForwardRef(styled.a)
   className="jest-auto-snapshots String Fixture"
   download={true}
+  fontWeight="0"
   href="jest-auto-snapshots String Fixture"
   rel="noopener noreferrer"
   target="_blank"
@@ -41,6 +44,7 @@ exports[`jest-auto-snapshots > Link Matches snapshot when passed all props 1`] =
 exports[`jest-auto-snapshots > Link Matches snapshot when passed only required props 1`] = `
 <ForwardRef(styled.a)
   download={false}
+  fontWeight={500}
   href="jest-auto-snapshots String Fixture"
   target="_self"
   title=""

--- a/src/components/Link/style.js
+++ b/src/components/Link/style.js
@@ -1,16 +1,11 @@
 import styled from 'styled-components';
 import { blue, blueDark } from '../style/colors';
-import {
-  fontFamily,
-  fontSize,
-  fontWeightMedium,
-  lineHeight,
-} from '../style/fonts';
+import { fontFamily, fontSize, lineHeight } from '../style/fonts';
 
 export const LinkStyled = styled.a`
   font-family: ${fontFamily};
   font-size: ${fontSize};
-  font-weight: ${fontWeightMedium};
+  font-weight: ${props => props.fontWeight};
   line-height: ${lineHeight};
   cursor: pointer;
   text-decoration: none;

--- a/src/documentation/examples/Link/BoldLink.jsx
+++ b/src/documentation/examples/Link/BoldLink.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import Link from '@bufferapp/ui/Link';
+
+/** Link with bolder weight */
+export default function ExampleLink() {
+  return (
+    <Link newTab href="http://buffer.com" fontWeight={700}>This is a link</Link>
+  );
+}

--- a/src/documentation/markdown/GettingStarted/CHANGELOG.md
+++ b/src/documentation/markdown/GettingStarted/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [5.54.1] - 2020-11-26
+- Adds fontWeight prop to Link: accepts fontWeightMedium (500) and fontWeightBold (700).
+
 ## [5.53.1] - 2020-11-17
 - Adds validation that Modal component actions and secondary actions have a label and callback present.
 


### PR DESCRIPTION
## Description

To allow `Link` components to have either medium or bold weights. It defaults to medium.

## Motivation and Context

Needed it for [this PR](https://github.com/bufferapp/buffer-account/pull/378), and [this design](https://www.figma.com/file/xOe4E7R2qIHTJYaNjsSAUL/Settings%3A-Channels?node-id=143%3A43).

## Screenshots (if appropriate):

<img width="626" alt="CleanShot 2020-11-26 at 16 44 52@2x" src="https://user-images.githubusercontent.com/720667/100370534-b7694a80-3006-11eb-899c-6ba2b394303b.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style and guidelines of this project. <!--- Link to Standards file coming soon. -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated the **CHANGELOG** document.
- [x] I have added tests to cover my changes.
- [x] I have performed a self-review of my own code
- [x] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] All new and existing tests passed.
- [ ] I have performed the accessibility audit of my UI changes according to the accessibility doc. <!--- Link to Accessibility Standards file coming soon. -->
- [ ] [Buffer Engineers] Someone from the Design team reviewed and approved my changes
- [ ] [Buffer Engineers] I have notified the BDS team of my changes in the #proj-design-system Slack channel
