### PR TITLE
add z-index to simple modal close button

### DIFF
--- a/src/components/SimpleModal/SimpleModal.jsx
+++ b/src/components/SimpleModal/SimpleModal.jsx
@@ -73,6 +73,7 @@ const CloseButton = styled.button`
   right: 16px;
   cursor: pointer;
   padding: 0;
+  z-index: 1;
 
   transition: transform 0.15s ease-out;
   svg {

--- a/src/documentation/markdown/GettingStarted/CHANGELOG.md
+++ b/src/documentation/markdown/GettingStarted/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [5.62.3] - 2021-03-10
+- add z-index to the simple modal close button
+
 ## [5.62.2] - 2021-03-09
 - Make the `loading` prop for the `Button` transient ([#284](https://github.com/bufferapp/ui/pull/284))
 


### PR DESCRIPTION

## Motivation and Context
adds a z-index so the button always shows on top of the content of the modal
