### PR TITLE
Add AnimationWrapper component

### DIFF
--- a/src/components/AnimationWrapper/AnimationWrapper.jsx
+++ b/src/components/AnimationWrapper/AnimationWrapper.jsx
@@ -95,5 +95,4 @@ AnimationWrapper.defaultProps = {
   onDismiss: () => {},
 };
 
-
 export default AnimationWrapper;

--- a/src/components/AnimationWrapper/AnimationWrapper.jsx
+++ b/src/components/AnimationWrapper/AnimationWrapper.jsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import { easeOutQuart } from '../style/animations';
 
 const AnimationContainer = styled.div`
+  animation-fill-mode: forwards;
   display: flex;
   align-items: ${({ align }) => align}}
   justify-content: ${({ justify }) => justify}}
@@ -22,24 +23,41 @@ const AnimationContainer = styled.div`
 const AnimationWrapper = ({
   align,
   children,
+  dismissing,
   duration,
   easing,
   justify,
   stageInAnimation,
-  stageOutAnimation
+  stageOutAnimation,
+  onDismiss,
 }) => {
   const [content, setContent] = useState(children);
   const [hasChanged, setHasChanged] = useState(false);
+  const [dismissed, setDismissed] = useState(false);
 
   useEffect(() => {
-    if (children !== content) {
+    if (children !== content && !dismissing) {
       setHasChanged(true);
+      setTimeout(() => {
+        setContent(children);
+        setHasChanged(false);
+      }, duration)
     }
-    setTimeout(() => {
-      setContent(children);
-      setHasChanged(false);
-    }, 300)
   }, [children])
+
+  useEffect(() => {
+    if (dismissing) {
+      // we are dismissing a bit earlier then animation end to prevent accidental re-render
+      setTimeout(() => {
+        setDismissed(true);
+        onDismiss();
+      }, duration - 10)
+    } }, [dismissing])
+
+  let className = 'fadeIn';
+  if (hasChanged || dismissing) {
+    className = 'fadeOut'
+  }
 
   return (
     <AnimationContainer
@@ -49,9 +67,9 @@ const AnimationWrapper = ({
       justify={justify}
       stageInAnimation={stageInAnimation}
       stageOutAnimation={stageOutAnimation}
-      className={hasChanged ? 'fadeOut' : 'fadeIn'}
+      className={className}
     >
-      {content}
+      {!dismissed && content}
     </AnimationContainer>
   );
 };
@@ -59,18 +77,22 @@ const AnimationWrapper = ({
 AnimationWrapper.propTypes = {
   align: PropTypes.string,
   children: PropTypes.node.isRequired,
+  dismissing: PropTypes.bool,
   duration: PropTypes.number,
   justify: PropTypes.string,
   easing: PropTypes.func,
   stageInAnimation: PropTypes.func.isRequired,
   stageOutAnimation: PropTypes.func.isRequired,
+  onDismiss: PropTypes.func,
 };
 
 AnimationWrapper.defaultProps = {
   align: 'center',
+  dismissing: false,
   duration: 300,
   justify: 'center',
   easing: easeOutQuart,
+  onDismiss: () => {},
 };
 
 

--- a/src/components/AnimationWrapper/AnimationWrapper.jsx
+++ b/src/components/AnimationWrapper/AnimationWrapper.jsx
@@ -1,0 +1,68 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { easeOutQuart } from '../style/animations';
+
+const AnimationContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  outline: none;
+
+  &.fadeIn {
+    animation: ${({ duration }) => `${duration}ms`} ${({ stageInAnimation }) => stageInAnimation} ${({ easing }) => easing};
+  }
+
+  &.fadeOut {
+    animation: ${({ duration }) => `${duration}ms`} ${({ stageOutAnimation }) => stageOutAnimation} ${({ easing }) => easing};
+  }
+`;
+
+const AnimationWrapper = ({
+  children,
+  duration,
+  easing,
+  stageInAnimation,
+  stageOutAnimation
+}) => {
+  const [content, setContent] = useState(children);
+  const [hasChanged, setHasChanged] = useState(false);
+
+  useEffect(() => {
+    if (children !== content) {
+      setHasChanged(true);
+    }
+    setTimeout(() => {
+      setContent(children);
+      setHasChanged(false);
+    }, 300)
+  }, [children])
+
+  return (
+    <AnimationContainer
+      duration={duration}
+      easing={easing}
+      stageInAnimation={stageInAnimation}
+      stageOutAnimation={stageOutAnimation}
+      className={hasChanged ? 'fadeOut' : 'fadeIn'}
+    >
+      {content}
+    </AnimationContainer>
+  );
+};
+
+AnimationWrapper.propTypes = {
+  children: PropTypes.node.isRequired,
+  duration: PropTypes.number,
+  easing: PropTypes.func,
+  stageInAnimation: PropTypes.func.isRequired,
+  stageOutAnimation: PropTypes.func.isRequired,
+};
+
+AnimationWrapper.defaultProps = {
+  duration: 300,
+  easing: easeOutQuart,
+};
+
+
+export default AnimationWrapper;

--- a/src/components/AnimationWrapper/AnimationWrapper.jsx
+++ b/src/components/AnimationWrapper/AnimationWrapper.jsx
@@ -5,9 +5,10 @@ import { easeOutQuart } from '../style/animations';
 
 const AnimationContainer = styled.div`
   display: flex;
-  align-items: center;
-  justify-content: center;
+  align-items: ${({ align }) => align}}
+  justify-content: ${({ justify }) => justify}}
   outline: none;
+  width: 100%;
 
   &.fadeIn {
     animation: ${({ duration }) => `${duration}ms`} ${({ stageInAnimation }) => stageInAnimation} ${({ easing }) => easing};
@@ -19,9 +20,11 @@ const AnimationContainer = styled.div`
 `;
 
 const AnimationWrapper = ({
+  align,
   children,
   duration,
   easing,
+  justify,
   stageInAnimation,
   stageOutAnimation
 }) => {
@@ -40,8 +43,10 @@ const AnimationWrapper = ({
 
   return (
     <AnimationContainer
+      align={align}
       duration={duration}
       easing={easing}
+      justify={justify}
       stageInAnimation={stageInAnimation}
       stageOutAnimation={stageOutAnimation}
       className={hasChanged ? 'fadeOut' : 'fadeIn'}
@@ -52,15 +57,19 @@ const AnimationWrapper = ({
 };
 
 AnimationWrapper.propTypes = {
+  align: PropTypes.string,
   children: PropTypes.node.isRequired,
   duration: PropTypes.number,
+  justify: PropTypes.string,
   easing: PropTypes.func,
   stageInAnimation: PropTypes.func.isRequired,
   stageOutAnimation: PropTypes.func.isRequired,
 };
 
 AnimationWrapper.defaultProps = {
+  align: 'center',
   duration: 300,
+  justify: 'center',
   easing: easeOutQuart,
 };
 

--- a/src/components/AnimationWrapper/AnimationWrapper.spec.js
+++ b/src/components/AnimationWrapper/AnimationWrapper.spec.js
@@ -1,0 +1,7 @@
+/* eslint-disable react/jsx-filename-extension */
+import snap from 'jest-auto-snapshots';
+import 'jest-styled-components';
+
+import AnimationWrapper from './AnimationWrapper';
+
+snap(AnimationWrapper, './AnimationWrapper.jsx');

--- a/src/components/AnimationWrapper/__snapshots__/AnimationWrapper.spec.js.snap
+++ b/src/components/AnimationWrapper/__snapshots__/AnimationWrapper.spec.js.snap
@@ -1,10 +1,26 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`jest-auto-snapshots > AnimationWrapper Matches snapshot when passed all props 1`] = `
+exports[`jest-auto-snapshots > AnimationWrapper Matches snapshot when boolean prop "dismissing" is set to: "false" 1`] = `
 <ForwardRef(styled.div)
+  align="jest-auto-snapshots String Fixture"
   className="fadeIn"
   duration={1}
   easing={[MockFunction]}
+  justify="jest-auto-snapshots String Fixture"
+  stageInAnimation={[MockFunction]}
+  stageOutAnimation={[MockFunction]}
+>
+  <NodeFixture />
+</ForwardRef(styled.div)>
+`;
+
+exports[`jest-auto-snapshots > AnimationWrapper Matches snapshot when passed all props 1`] = `
+<ForwardRef(styled.div)
+  align="jest-auto-snapshots String Fixture"
+  className="fadeOut"
+  duration={1}
+  easing={[MockFunction]}
+  justify="jest-auto-snapshots String Fixture"
   stageInAnimation={[MockFunction]}
   stageOutAnimation={[MockFunction]}
 >
@@ -14,9 +30,11 @@ exports[`jest-auto-snapshots > AnimationWrapper Matches snapshot when passed all
 
 exports[`jest-auto-snapshots > AnimationWrapper Matches snapshot when passed only required props 1`] = `
 <ForwardRef(styled.div)
+  align="center"
   className="fadeIn"
   duration={300}
   easing="cubic-bezier(0.25, 1, 0.5, 1)"
+  justify="center"
   stageInAnimation={[MockFunction]}
   stageOutAnimation={[MockFunction]}
 >

--- a/src/components/AnimationWrapper/__snapshots__/AnimationWrapper.spec.js.snap
+++ b/src/components/AnimationWrapper/__snapshots__/AnimationWrapper.spec.js.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`jest-auto-snapshots > AnimationWrapper Matches snapshot when passed all props 1`] = `
+<ForwardRef(styled.div)
+  className="fadeIn"
+  duration={1}
+  easing={[MockFunction]}
+  stageInAnimation={[MockFunction]}
+  stageOutAnimation={[MockFunction]}
+>
+  <NodeFixture />
+</ForwardRef(styled.div)>
+`;
+
+exports[`jest-auto-snapshots > AnimationWrapper Matches snapshot when passed only required props 1`] = `
+<ForwardRef(styled.div)
+  className="fadeIn"
+  duration={300}
+  easing="cubic-bezier(0.25, 1, 0.5, 1)"
+  stageInAnimation={[MockFunction]}
+  stageOutAnimation={[MockFunction]}
+>
+  <NodeFixture />
+</ForwardRef(styled.div)>
+`;

--- a/src/components/AnimationWrapper/hook.js
+++ b/src/components/AnimationWrapper/hook.js
@@ -1,0 +1,16 @@
+import { useState } from 'react';
+import AnimationWrapper from './AnimationWrapper';
+
+function useAnimation(props) {
+  const [dismissing, setDismissing] = useState(false);
+  const animationProps = {...props, dismissing}
+
+  return {
+    AnimationWrapper,
+    animationProps,
+    dismiss: () => setDismissing(true),
+  }
+
+}
+
+export default useAnimation;

--- a/src/components/AnimationWrapper/index.js
+++ b/src/components/AnimationWrapper/index.js
@@ -1,0 +1,1 @@
+export { default } from './AnimationWrapper';

--- a/src/components/AnimationWrapper/index.js
+++ b/src/components/AnimationWrapper/index.js
@@ -1,1 +1,2 @@
 export { default } from './AnimationWrapper';
+export useAnimation from './hook';

--- a/src/components/Notice/Notice.jsx
+++ b/src/components/Notice/Notice.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { borderRadius } from '../style/borders';
@@ -59,18 +59,25 @@ const CloseButton = styled.button`
 `;
 
 function Notice({ children, dismiss, type }) {
+  const [dismissing, setDismissing] = useState(false);
+
   return (
     <AnimationWrapper
       justify="flex-end"
       stageInAnimation={stageInRight}
       stageOutAnimation={stageOutRight}
       duration={300}
+      dismissing={dismissing}
+      onDismiss={dismiss}
     >
       <NoticeWrapper type={type} dismiss={dismiss}>
         {type === 'warning' && <WarningIcon />}
         {children}
         {dismiss && (
-          <CloseButton type={type} onClick={() => dismiss()}>
+          <CloseButton
+            type={type}
+            onClick={() => setDismissing(true)}
+          >
             <Cross />
           </CloseButton>
         )}

--- a/src/components/Notice/Notice.jsx
+++ b/src/components/Notice/Notice.jsx
@@ -7,7 +7,7 @@ import Warning from '../Icon/Icons/Warning';
 import Cross from '../Icon/Icons/Cross';
 import { grayDark, grayLighter, grayDarker } from '../style/colors';
 import AnimationWrapper from '../AnimationWrapper';
-import { stageInRight, stageOutRight } from '../style/animations';
+import { stageInRight, fadeOut } from '../style/animations';
 
 const colorMap = {
   warning: {
@@ -65,7 +65,7 @@ function Notice({ children, dismiss, type }) {
     <AnimationWrapper
       justify="flex-end"
       stageInAnimation={stageInRight}
-      stageOutAnimation={stageOutRight}
+      stageOutAnimation={fadeOut}
       duration={300}
       dismissing={dismissing}
       onDismiss={dismiss}

--- a/src/components/Notice/Notice.jsx
+++ b/src/components/Notice/Notice.jsx
@@ -6,6 +6,8 @@ import { fontSize } from '../style/fonts';
 import Warning from '../Icon/Icons/Warning';
 import Cross from '../Icon/Icons/Cross';
 import { grayDark, grayLighter, grayDarker } from '../style/colors';
+import AnimationWrapper from '../AnimationWrapper';
+import { stageInRight, stageOutRight } from '../style/animations';
 
 const colorMap = {
   warning: {
@@ -58,15 +60,22 @@ const CloseButton = styled.button`
 
 function Notice({ children, dismiss, type }) {
   return (
-    <NoticeWrapper type={type}>
-      {type === 'warning' && <WarningIcon />}
-      {children}
-      {dismiss && (
-        <CloseButton type={type} onClick={() => dismiss()}>
-          <Cross />
-        </CloseButton>
-      )}
-    </NoticeWrapper>
+    <AnimationWrapper
+      justify="flex-end"
+      stageInAnimation={stageInRight}
+      stageOutAnimation={stageOutRight}
+      duration={250}
+    >
+      <NoticeWrapper type={type}>
+        {type === 'warning' && <WarningIcon />}
+        {children}
+        {dismiss && (
+          <CloseButton type={type} onClick={() => dismiss()}>
+            <Cross />
+          </CloseButton>
+        )}
+      </NoticeWrapper>
+    </AnimationWrapper>
   );
 }
 

--- a/src/components/Notice/Notice.jsx
+++ b/src/components/Notice/Notice.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { borderRadius } from '../style/borders';
@@ -6,7 +6,7 @@ import { fontSize } from '../style/fonts';
 import Warning from '../Icon/Icons/Warning';
 import Cross from '../Icon/Icons/Cross';
 import { grayDark, grayLighter, grayDarker } from '../style/colors';
-import AnimationWrapper from '../AnimationWrapper';
+import { useAnimation } from '../AnimationWrapper';
 import { stageInRight, fadeOut } from '../style/animations';
 
 const colorMap = {
@@ -59,24 +59,22 @@ const CloseButton = styled.button`
 `;
 
 function Notice({ children, dismiss, type }) {
-  const [dismissing, setDismissing] = useState(false);
+  const { AnimationWrapper, dismiss:dismissAnimationWrapper, animationProps } = useAnimation({
+    justify: 'flex-end',
+    stageInAnimation: stageInRight,
+    stageOutAnimation: fadeOut,
+    onDismiss: dismiss,
+  })
 
   return (
-    <AnimationWrapper
-      justify="flex-end"
-      stageInAnimation={stageInRight}
-      stageOutAnimation={fadeOut}
-      duration={300}
-      dismissing={dismissing}
-      onDismiss={dismiss}
-    >
+    <AnimationWrapper {...animationProps}>
       <NoticeWrapper type={type} dismiss={dismiss}>
         {type === 'warning' && <WarningIcon />}
         {children}
         {dismiss && (
           <CloseButton
             type={type}
-            onClick={() => setDismissing(true)}
+            onClick={() => dismissAnimationWrapper()}
           >
             <Cross />
           </CloseButton>

--- a/src/components/Notice/Notice.jsx
+++ b/src/components/Notice/Notice.jsx
@@ -28,7 +28,7 @@ const NoticeWrapper = styled.div`
   background: ${props => colorMap[props.type].background};
   border-radius: ${borderRadius};
   font-size: ${fontSize};
-  padding: 16px 16px;
+  padding: 16px ${({ dismiss }) => dismiss ? '36px' : '16px' } 16px 16px;
   display: flex;
   justify-content: flex-start;
   position: relative;
@@ -64,9 +64,9 @@ function Notice({ children, dismiss, type }) {
       justify="flex-end"
       stageInAnimation={stageInRight}
       stageOutAnimation={stageOutRight}
-      duration={250}
+      duration={300}
     >
-      <NoticeWrapper type={type}>
+      <NoticeWrapper type={type} dismiss={dismiss}>
         {type === 'warning' && <WarningIcon />}
         {children}
         {dismiss && (

--- a/src/components/Notice/__snapshots__/Notice.spec.js.snap
+++ b/src/components/Notice/__snapshots__/Notice.spec.js.snap
@@ -1,23 +1,135 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`jest-auto-snapshots > Notice Matches snapshot when passed all props 1`] = `
-<ForwardRef(styled.div)
-  type="jest-auto-snapshots String Fixture"
+<AnimationWrapper
+  align="center"
+  dismissing={false}
+  duration={300}
+  easing="cubic-bezier(0.25, 1, 0.5, 1)"
+  justify="flex-end"
+  onDismiss={[MockFunction]}
+  stageInAnimation={
+    Keyframes {
+      "id": "sc-keyframes-jALQVJ",
+      "inject": [Function],
+      "name": "jALQVJ",
+      "stringifyArgs": Array [
+        "
+  0% {
+    transform: translateX(200px);
+    opacity: 0;
+  }
+
+  100% {
+    transform: translateX(0);
+    opacity: 1;
+  }
+",
+        "jALQVJ",
+        "@keyframes",
+      ],
+      "toString": [Function],
+    }
+  }
+  stageOutAnimation={
+    Keyframes {
+      "id": "sc-keyframes-bjhQjg",
+      "inject": [Function],
+      "name": "bjhQjg",
+      "stringifyArgs": Array [
+        "
+  0% {
+    transform: scale(1) translateY(0);
+    opacity: 1;
+  }
+
+  100% {
+    transform: scale(1.05) translateY(-10px);
+    opacity: 0;
+  }
+",
+        "bjhQjg",
+        "@keyframes",
+      ],
+      "toString": [Function],
+    }
+  }
 >
-  <NodeFixture />
-  <ForwardRef(styled.button)
-    onClick={[Function]}
+  <ForwardRef(styled.div)
+    dismiss={[MockFunction]}
     type="jest-auto-snapshots String Fixture"
   >
-    <CrossIcon />
-  </ForwardRef(styled.button)>
-</ForwardRef(styled.div)>
+    <NodeFixture />
+    <ForwardRef(styled.button)
+      onClick={[Function]}
+      type="jest-auto-snapshots String Fixture"
+    >
+      <CrossIcon />
+    </ForwardRef(styled.button)>
+  </ForwardRef(styled.div)>
+</AnimationWrapper>
 `;
 
 exports[`jest-auto-snapshots > Notice Matches snapshot when passed only required props 1`] = `
-<ForwardRef(styled.div)
-  type="jest-auto-snapshots String Fixture"
+<AnimationWrapper
+  align="center"
+  dismissing={false}
+  duration={300}
+  easing="cubic-bezier(0.25, 1, 0.5, 1)"
+  justify="flex-end"
+  onDismiss={null}
+  stageInAnimation={
+    Keyframes {
+      "id": "sc-keyframes-jALQVJ",
+      "inject": [Function],
+      "name": "jALQVJ",
+      "stringifyArgs": Array [
+        "
+  0% {
+    transform: translateX(200px);
+    opacity: 0;
+  }
+
+  100% {
+    transform: translateX(0);
+    opacity: 1;
+  }
+",
+        "jALQVJ",
+        "@keyframes",
+      ],
+      "toString": [Function],
+    }
+  }
+  stageOutAnimation={
+    Keyframes {
+      "id": "sc-keyframes-bjhQjg",
+      "inject": [Function],
+      "name": "bjhQjg",
+      "stringifyArgs": Array [
+        "
+  0% {
+    transform: scale(1) translateY(0);
+    opacity: 1;
+  }
+
+  100% {
+    transform: scale(1.05) translateY(-10px);
+    opacity: 0;
+  }
+",
+        "bjhQjg",
+        "@keyframes",
+      ],
+      "toString": [Function],
+    }
+  }
 >
-  <NodeFixture />
-</ForwardRef(styled.div)>
+  <ForwardRef(styled.div)
+    dismiss={null}
+    type="jest-auto-snapshots String Fixture"
+  >
+    <NodeFixture />
+  </ForwardRef(styled.div)>
+</AnimationWrapper>
 `;

--- a/src/components/Notification/Notification.jsx
+++ b/src/components/Notification/Notification.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import {
   Container,
@@ -8,7 +8,7 @@ import {
   ButtonsRow,
   ButtonStyled,
 } from './style';
-import AnimationWrapper from '../AnimationWrapper';
+import { useAnimation } from '../AnimationWrapper';
 import { stageInTop, fadeOut } from '../style/animations';
 
 function Notification({
@@ -18,21 +18,19 @@ function Notification({
   action,
   secondaryAction,
 }) {
-  const [dismissing, setDismissing] = useState(false);
+  const { AnimationWrapper, dismiss:dismissAnimationWrapper, animationProps } = useAnimation({
+    justify: 'flex-end',
+    stageInAnimation: stageInTop,
+    stageOutAnimation: fadeOut,
+    onDismiss: onClose,
+  })
 
   return (
-    <AnimationWrapper
-      justify="flex-end"
-      stageInAnimation={stageInTop}
-      stageOutAnimation={fadeOut}
-      duration={300}
-      dismissing={dismissing}
-      onDismiss={onClose}
-    >
+    <AnimationWrapper {...animationProps}>
       <Container>
         <TextRow>
           <Text>{text}</Text>
-          <Icon onClick={() => setDismissing(true)} />
+          <Icon onClick={() => dismissAnimationWrapper()} />
         </TextRow>
         {type === 'action' && (
           <ButtonsRow>

--- a/src/components/Notification/Notification.jsx
+++ b/src/components/Notification/Notification.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import {
   Container,
@@ -8,35 +8,49 @@ import {
   ButtonsRow,
   ButtonStyled,
 } from './style';
+import AnimationWrapper from '../AnimationWrapper';
+import { stageInTop, fadeOut } from '../style/animations';
 
-const Notification = ({
+function Notification({
   text,
   onClose,
   type,
   action,
   secondaryAction,
-}) => (
-  <Container>
-    <TextRow>
-      <Text>{text}</Text>
-      <Icon onClick={onClose} />
-    </TextRow>
-    {type === 'action' && (
-      <ButtonsRow>
-        {action && (
-          <ButtonStyled onClick={action.callback} label={action.label} type="text" />
+}) {
+  const [dismissing, setDismissing] = useState(false);
+
+  return (
+    <AnimationWrapper
+      justify="flex-end"
+      stageInAnimation={stageInTop}
+      stageOutAnimation={fadeOut}
+      duration={300}
+      dismissing={dismissing}
+      onDismiss={onClose}
+    >
+      <Container>
+        <TextRow>
+          <Text>{text}</Text>
+          <Icon onClick={() => setDismissing(true)} />
+        </TextRow>
+        {type === 'action' && (
+          <ButtonsRow>
+            {action && (
+              <ButtonStyled onClick={action.callback} label={action.label} type="text" />
+            )}
+            {secondaryAction && (
+              <ButtonStyled
+                onClick={secondaryAction.callback}
+                label={secondaryAction.label}
+                type="text"
+              />)}
+          </ButtonsRow>
         )}
-        {secondaryAction && (
-          <ButtonStyled
-            onClick={secondaryAction.callback}
-            label={secondaryAction.label}
-            type="text"
-          />
-        )}
-      </ButtonsRow>
-    )}
-  </Container>
-);
+      </Container>
+    </AnimationWrapper>
+  );
+}
 
 Notification.propTypes = {
   /** Text of the notification */

--- a/src/components/Notification/__snapshots__/Notification.spec.js.snap
+++ b/src/components/Notification/__snapshots__/Notification.spec.js.snap
@@ -1,39 +1,149 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`jest-auto-snapshots > Notification Matches snapshot when passed all props 1`] = `
-<ForwardRef(styled.div)>
+<AnimationWrapper
+  align="center"
+  dismissing={false}
+  duration={300}
+  easing="cubic-bezier(0.25, 1, 0.5, 1)"
+  justify="flex-end"
+  onDismiss={[MockFunction]}
+  stageInAnimation={
+    Keyframes {
+      "id": "sc-keyframes-ciDIsA",
+      "inject": [Function],
+      "name": "ciDIsA",
+      "stringifyArgs": Array [
+        "
+  0% {
+    transform: translateY(-200px);
+    opacity: 0;
+  }
+
+  100% {
+    transform: translateY(0);
+    opacity: 1;
+  }
+",
+        "ciDIsA",
+        "@keyframes",
+      ],
+      "toString": [Function],
+    }
+  }
+  stageOutAnimation={
+    Keyframes {
+      "id": "sc-keyframes-bjhQjg",
+      "inject": [Function],
+      "name": "bjhQjg",
+      "stringifyArgs": Array [
+        "
+  0% {
+    transform: scale(1) translateY(0);
+    opacity: 1;
+  }
+
+  100% {
+    transform: scale(1.05) translateY(-10px);
+    opacity: 0;
+  }
+",
+        "bjhQjg",
+        "@keyframes",
+      ],
+      "toString": [Function],
+    }
+  }
+>
   <ForwardRef(styled.div)>
     <ForwardRef(styled.div)>
-      jest-auto-snapshots String Fixture
+      <ForwardRef(styled.div)>
+        jest-auto-snapshots String Fixture
+      </ForwardRef(styled.div)>
+      <ForwardRef(Styled(CrossIcon))
+        onClick={[Function]}
+      />
     </ForwardRef(styled.div)>
-    <ForwardRef(Styled(CrossIcon))
-      onClick={[MockFunction]}
-    />
+    <ForwardRef(styled.div)>
+      <ForwardRef(Styled(Button))
+        label="jest-auto-snapshots String Fixture"
+        onClick={[MockFunction]}
+        type="text"
+      />
+      <ForwardRef(Styled(Button))
+        label="jest-auto-snapshots String Fixture"
+        onClick={[MockFunction]}
+        type="text"
+      />
+    </ForwardRef(styled.div)>
   </ForwardRef(styled.div)>
-  <ForwardRef(styled.div)>
-    <ForwardRef(Styled(Button))
-      label="jest-auto-snapshots String Fixture"
-      onClick={[MockFunction]}
-      type="text"
-    />
-    <ForwardRef(Styled(Button))
-      label="jest-auto-snapshots String Fixture"
-      onClick={[MockFunction]}
-      type="text"
-    />
-  </ForwardRef(styled.div)>
-</ForwardRef(styled.div)>
+</AnimationWrapper>
 `;
 
 exports[`jest-auto-snapshots > Notification Matches snapshot when passed only required props 1`] = `
-<ForwardRef(styled.div)>
+<AnimationWrapper
+  align="center"
+  dismissing={false}
+  duration={300}
+  easing="cubic-bezier(0.25, 1, 0.5, 1)"
+  justify="flex-end"
+  onDismiss={[MockFunction]}
+  stageInAnimation={
+    Keyframes {
+      "id": "sc-keyframes-ciDIsA",
+      "inject": [Function],
+      "name": "ciDIsA",
+      "stringifyArgs": Array [
+        "
+  0% {
+    transform: translateY(-200px);
+    opacity: 0;
+  }
+
+  100% {
+    transform: translateY(0);
+    opacity: 1;
+  }
+",
+        "ciDIsA",
+        "@keyframes",
+      ],
+      "toString": [Function],
+    }
+  }
+  stageOutAnimation={
+    Keyframes {
+      "id": "sc-keyframes-bjhQjg",
+      "inject": [Function],
+      "name": "bjhQjg",
+      "stringifyArgs": Array [
+        "
+  0% {
+    transform: scale(1) translateY(0);
+    opacity: 1;
+  }
+
+  100% {
+    transform: scale(1.05) translateY(-10px);
+    opacity: 0;
+  }
+",
+        "bjhQjg",
+        "@keyframes",
+      ],
+      "toString": [Function],
+    }
+  }
+>
   <ForwardRef(styled.div)>
     <ForwardRef(styled.div)>
-      jest-auto-snapshots String Fixture
+      <ForwardRef(styled.div)>
+        jest-auto-snapshots String Fixture
+      </ForwardRef(styled.div)>
+      <ForwardRef(Styled(CrossIcon))
+        onClick={[Function]}
+      />
     </ForwardRef(styled.div)>
-    <ForwardRef(Styled(CrossIcon))
-      onClick={[MockFunction]}
-    />
   </ForwardRef(styled.div)>
-</ForwardRef(styled.div)>
+</AnimationWrapper>
 `;

--- a/src/components/SimpleModal/SimpleModal.jsx
+++ b/src/components/SimpleModal/SimpleModal.jsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from 'react';
+import React, { useRef, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import styled, { keyframes } from 'styled-components';
 import { Cross } from '../Icon';
@@ -18,7 +18,7 @@ const fadeIn = keyframes`
   }
 `;
 
-const stagingAnimation = keyframes`
+const stageInAnimation = keyframes`
   0% {
     transform: scale(.5);
     opacity: 0;
@@ -27,6 +27,18 @@ const stagingAnimation = keyframes`
   100% {
     transform: scale(1);
     opacity: 1;
+  }
+`;
+
+const stageOutAnimation = keyframes`
+  0% {
+    transform: scale(1);
+    opacity: 1;
+  }
+
+  100% {
+    transform: scale(.5);
+    opacity: 0;
   }
 `;
 
@@ -62,7 +74,13 @@ const Modal = styled.div`
   justify-content: center;
   outline: none;
 
-  animation: 300ms ${stagingAnimation} ${easeOutQuart};
+  &.fadeIn {
+    animation: 300ms ${stageInAnimation} ${easeOutQuart};
+  }
+
+  &.fadeOut {
+    animation: 300ms ${stageOutAnimation} ${easeOutQuart};
+  }
 `;
 
 const CloseButton = styled.button`
@@ -89,6 +107,9 @@ const CloseButton = styled.button`
 `;
 
 const SimpleModal = ({ children, closeAction }) => {
+  const [modalCotent, setModalCotent] = useState(children);
+  const [hasChanged, setHasChanged] = useState(false);
+
   const modalRef = useRef(null);
   const containerRef = useRef(null);
 
@@ -132,11 +153,22 @@ const SimpleModal = ({ children, closeAction }) => {
     return () => document.removeEventListener('keydown', keyListener);
   }, []);
 
+  useEffect(() => {
+    if (children !== modalCotent) {
+      setHasChanged(true);
+    }
+    setTimeout(() => {
+      setModalCotent(children);
+      setHasChanged(false);
+    }, 300)
+  }, [children])
+
   return (
     <Container ref={containerRef} role="dialog" aria-modal="true">
       <Modal
         ref={modalRef}
         tabIndex="0" // this needs to have a tabIndex so that it can listen for the ESC key
+        className={hasChanged ? 'fadeOut' : 'fadeIn'}
       >
         <CloseButton
           onClick={() => {
@@ -145,7 +177,7 @@ const SimpleModal = ({ children, closeAction }) => {
         >
           <Cross />
         </CloseButton>
-        {children}
+        {modalCotent}
       </Modal>
     </Container>
   );

--- a/src/components/SimpleModal/SimpleModal.jsx
+++ b/src/components/SimpleModal/SimpleModal.jsx
@@ -2,9 +2,9 @@ import React, { useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import styled, { keyframes } from 'styled-components';
 import { Cross } from '../Icon';
-import AnimationWrapper from '../AnimationWrapper';
 import { white, red } from '../style/colors';
-import { easeOutQuart, stageInAnimation, stageOutAnimation } from '../style/animations';
+import AnimationWrapper from '../AnimationWrapper';
+import { easeOutQuart, stageInCenter, stageOutCenter } from '../style/animations';
 
 const ESCAPE_KEY = 27;
 const TAB_KEY = 9;
@@ -121,7 +121,7 @@ const SimpleModal = ({ children, closeAction }) => {
 
   return (
     <Container ref={containerRef} role="dialog" aria-modal="true">
-      <AnimationWrapper stageInAnimation={stageInAnimation} stageOutAnimation={stageOutAnimation} duration={450}>
+      <AnimationWrapper stageInAnimation={stageInCenter} stageOutAnimation={stageOutCenter} duration={450}>
         <Modal
           ref={modalRef}
           tabIndex="0" // this needs to have a tabIndex so that it can listen for the ESC key

--- a/src/components/SimpleModal/SimpleModal.jsx
+++ b/src/components/SimpleModal/SimpleModal.jsx
@@ -4,7 +4,7 @@ import styled, { keyframes } from 'styled-components';
 import { Cross } from '../Icon';
 import AnimationWrapper from '../AnimationWrapper';
 import { white, red } from '../style/colors';
-import { easeOutQuart } from '../style/animations';
+import { easeOutQuart, stageInAnimation, stageOutAnimation } from '../style/animations';
 
 const ESCAPE_KEY = 27;
 const TAB_KEY = 9;
@@ -16,30 +16,6 @@ const fadeIn = keyframes`
 
   100% {
     opacity: 1;
-  }
-`;
-
-const stageInAnimation = keyframes`
-  0% {
-    transform: scale(.5);
-    opacity: 0;
-  }
-
-  100% {
-    transform: scale(1);
-    opacity: 1;
-  }
-`;
-
-const stageOutAnimation = keyframes`
-  0% {
-    transform: scale(1);
-    opacity: 1;
-  }
-
-  100% {
-    transform: scale(.5);
-    opacity: 0;
   }
 `;
 

--- a/src/components/SimpleModal/SimpleModal.jsx
+++ b/src/components/SimpleModal/SimpleModal.jsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from 'react';
+import React, { useRef, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import styled, { keyframes } from 'styled-components';
 import { Cross } from '../Icon';
@@ -78,6 +78,7 @@ const CloseButton = styled.button`
 const SimpleModal = ({ children, closeAction }) => {
   const modalRef = useRef(null);
   const containerRef = useRef(null);
+  const [dismissing, setDismissing] = useState(false);
 
   const handleTabKey = e => {
     const focusableModalElements = modalRef.current.querySelectorAll(
@@ -99,13 +100,13 @@ const SimpleModal = ({ children, closeAction }) => {
   };
 
   const keyListenersMap = new Map([
-    [ESCAPE_KEY, () => closeAction()],
+    [ESCAPE_KEY, () => setDismissing(true)],
     [TAB_KEY, handleTabKey],
   ]);
 
   const clickToClose = e => {
     if (e.target !== containerRef.current) return;
-    closeAction();
+    setDismissing(true);
   };
 
   useEffect(() => {
@@ -121,16 +122,18 @@ const SimpleModal = ({ children, closeAction }) => {
 
   return (
     <Container ref={containerRef} role="dialog" aria-modal="true">
-      <AnimationWrapper stageInAnimation={stageInCenter} stageOutAnimation={stageOutCenter} duration={450}>
+      <AnimationWrapper
+        stageInAnimation={stageInCenter}
+        stageOutAnimation={stageOutCenter}
+        duration={350}
+        dismissing={dismissing}
+        onDismiss={closeAction}
+      >
         <Modal
           ref={modalRef}
           tabIndex="0" // this needs to have a tabIndex so that it can listen for the ESC key
         >
-          <CloseButton
-            onClick={() => {
-              closeAction();
-            }}
-          >
+          <CloseButton onClick={() => setDismissing(true)}>
             <Cross />
           </CloseButton>
           {children}

--- a/src/components/SimpleModal/SimpleModal.jsx
+++ b/src/components/SimpleModal/SimpleModal.jsx
@@ -1,9 +1,9 @@
-import React, { useRef, useEffect, useState } from 'react';
+import React, { useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import styled, { keyframes } from 'styled-components';
 import { Cross } from '../Icon';
 import { white, red } from '../style/colors';
-import AnimationWrapper from '../AnimationWrapper';
+import { useAnimation } from '../AnimationWrapper';
 import { easeOutQuart, stageInCenter, stageOutCenter } from '../style/animations';
 
 const ESCAPE_KEY = 27;
@@ -78,7 +78,12 @@ const CloseButton = styled.button`
 const SimpleModal = ({ children, closeAction }) => {
   const modalRef = useRef(null);
   const containerRef = useRef(null);
-  const [dismissing, setDismissing] = useState(false);
+  const { AnimationWrapper, dismiss:dismissAnimationWrapper, animationProps } = useAnimation({
+    stageInAnimation: stageInCenter,
+    stageOutAnimation: stageOutCenter,
+    duration: 400,
+    onDismiss: closeAction,
+  })
 
   const handleTabKey = e => {
     const focusableModalElements = modalRef.current.querySelectorAll(
@@ -100,13 +105,13 @@ const SimpleModal = ({ children, closeAction }) => {
   };
 
   const keyListenersMap = new Map([
-    [ESCAPE_KEY, () => setDismissing(true)],
+    [ESCAPE_KEY, () => dismissAnimationWrapper],
     [TAB_KEY, handleTabKey],
   ]);
 
   const clickToClose = e => {
     if (e.target !== containerRef.current) return;
-    setDismissing(true);
+    dismissAnimationWrapper();
   };
 
   useEffect(() => {
@@ -122,18 +127,12 @@ const SimpleModal = ({ children, closeAction }) => {
 
   return (
     <Container ref={containerRef} role="dialog" aria-modal="true">
-      <AnimationWrapper
-        stageInAnimation={stageInCenter}
-        stageOutAnimation={stageOutCenter}
-        duration={350}
-        dismissing={dismissing}
-        onDismiss={closeAction}
-      >
+      <AnimationWrapper {...animationProps}>
         <Modal
           ref={modalRef}
           tabIndex="0" // this needs to have a tabIndex so that it can listen for the ESC key
         >
-          <CloseButton onClick={() => setDismissing(true)}>
+          <CloseButton onClick={() => dismissAnimationWrapper()}>
             <Cross />
           </CloseButton>
           {children}

--- a/src/components/SimpleModal/SimpleModal.jsx
+++ b/src/components/SimpleModal/SimpleModal.jsx
@@ -1,7 +1,8 @@
-import React, { useRef, useEffect, useState } from 'react';
+import React, { useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import styled, { keyframes } from 'styled-components';
 import { Cross } from '../Icon';
+import AnimationWrapper from '../AnimationWrapper';
 import { white, red } from '../style/colors';
 import { easeOutQuart } from '../style/animations';
 
@@ -73,14 +74,6 @@ const Modal = styled.div`
   align-items: center;
   justify-content: center;
   outline: none;
-
-  &.fadeIn {
-    animation: 300ms ${stageInAnimation} ${easeOutQuart};
-  }
-
-  &.fadeOut {
-    animation: 300ms ${stageOutAnimation} ${easeOutQuart};
-  }
 `;
 
 const CloseButton = styled.button`
@@ -107,9 +100,6 @@ const CloseButton = styled.button`
 `;
 
 const SimpleModal = ({ children, closeAction }) => {
-  const [modalCotent, setModalCotent] = useState(children);
-  const [hasChanged, setHasChanged] = useState(false);
-
   const modalRef = useRef(null);
   const containerRef = useRef(null);
 
@@ -153,32 +143,23 @@ const SimpleModal = ({ children, closeAction }) => {
     return () => document.removeEventListener('keydown', keyListener);
   }, []);
 
-  useEffect(() => {
-    if (children !== modalCotent) {
-      setHasChanged(true);
-    }
-    setTimeout(() => {
-      setModalCotent(children);
-      setHasChanged(false);
-    }, 300)
-  }, [children])
-
   return (
     <Container ref={containerRef} role="dialog" aria-modal="true">
-      <Modal
-        ref={modalRef}
-        tabIndex="0" // this needs to have a tabIndex so that it can listen for the ESC key
-        className={hasChanged ? 'fadeOut' : 'fadeIn'}
-      >
-        <CloseButton
-          onClick={() => {
-            closeAction();
-          }}
+      <AnimationWrapper stageInAnimation={stageInAnimation} stageOutAnimation={stageOutAnimation} duration={450}>
+        <Modal
+          ref={modalRef}
+          tabIndex="0" // this needs to have a tabIndex so that it can listen for the ESC key
         >
-          <Cross />
-        </CloseButton>
-        {modalCotent}
-      </Modal>
+          <CloseButton
+            onClick={() => {
+              closeAction();
+            }}
+          >
+            <Cross />
+          </CloseButton>
+          {children}
+        </Modal>
+      </AnimationWrapper>
     </Container>
   );
 };

--- a/src/components/SimpleModal/__snapshots__/SimpleModal.spec.js.snap
+++ b/src/components/SimpleModal/__snapshots__/SimpleModal.spec.js.snap
@@ -5,15 +5,66 @@ exports[`jest-auto-snapshots > SimpleModal Matches snapshot when passed only req
   aria-modal="true"
   role="dialog"
 >
-  <ForwardRef(styled.div)
-    tabIndex="0"
+  <AnimationWrapper
+    duration={450}
+    easing="cubic-bezier(0.25, 1, 0.5, 1)"
+    stageInAnimation={
+      Keyframes {
+        "id": "sc-keyframes-bQtjaF",
+        "inject": [Function],
+        "name": "bQtjaF",
+        "stringifyArgs": Array [
+          "
+  0% {
+    transform: scale(.5);
+    opacity: 0;
+  }
+
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+",
+          "bQtjaF",
+          "@keyframes",
+        ],
+        "toString": [Function],
+      }
+    }
+    stageOutAnimation={
+      Keyframes {
+        "id": "sc-keyframes-hsHpqF",
+        "inject": [Function],
+        "name": "hsHpqF",
+        "stringifyArgs": Array [
+          "
+  0% {
+    transform: scale(1);
+    opacity: 1;
+  }
+
+  100% {
+    transform: scale(.5);
+    opacity: 0;
+  }
+",
+          "hsHpqF",
+          "@keyframes",
+        ],
+        "toString": [Function],
+      }
+    }
   >
-    <ForwardRef(styled.button)
-      onClick={[Function]}
+    <ForwardRef(styled.div)
+      tabIndex="0"
     >
-      <CrossIcon />
-    </ForwardRef(styled.button)>
-    <NodeFixture />
-  </ForwardRef(styled.div)>
+      <ForwardRef(styled.button)
+        onClick={[Function]}
+      >
+        <CrossIcon />
+      </ForwardRef(styled.button)>
+      <NodeFixture />
+    </ForwardRef(styled.div)>
+  </AnimationWrapper>
 </ForwardRef(styled.div)>
 `;

--- a/src/components/SimpleModal/__snapshots__/SimpleModal.spec.js.snap
+++ b/src/components/SimpleModal/__snapshots__/SimpleModal.spec.js.snap
@@ -6,8 +6,12 @@ exports[`jest-auto-snapshots > SimpleModal Matches snapshot when passed only req
   role="dialog"
 >
   <AnimationWrapper
-    duration={450}
+    align="center"
+    dismissing={false}
+    duration={350}
     easing="cubic-bezier(0.25, 1, 0.5, 1)"
+    justify="center"
+    onDismiss={[MockFunction]}
     stageInAnimation={
       Keyframes {
         "id": "sc-keyframes-bQtjaF",

--- a/src/components/SimpleModal/__snapshots__/SimpleModal.spec.js.snap
+++ b/src/components/SimpleModal/__snapshots__/SimpleModal.spec.js.snap
@@ -8,7 +8,7 @@ exports[`jest-auto-snapshots > SimpleModal Matches snapshot when passed only req
   <AnimationWrapper
     align="center"
     dismissing={false}
-    duration={350}
+    duration={400}
     easing="cubic-bezier(0.25, 1, 0.5, 1)"
     justify="center"
     onDismiss={[MockFunction]}

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -21,3 +21,4 @@ export { default as Switch } from './Switch';
 export { default as Notice } from './Notice';
 export { default as States } from './States';
 export { default as SimpleModal } from './SimpleModal';
+export { default as AnimationWrapper } from './AnimationWrapper';

--- a/src/components/style/animations.js
+++ b/src/components/style/animations.js
@@ -1,1 +1,27 @@
+import { keyframes } from 'styled-components';
+
 export const easeOutQuart = 'cubic-bezier(0.25, 1, 0.5, 1)';
+
+export const stageInAnimation = keyframes`
+  0% {
+    transform: scale(.5);
+    opacity: .5;
+  }
+
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+`;
+
+export const stageOutAnimation = keyframes`
+  0% {
+    transform: scale(1);
+    opacity: 1;
+  }
+
+  100% {
+    transform: scale(.5);
+    opacity: .5;
+  }
+`;

--- a/src/components/style/animations.js
+++ b/src/components/style/animations.js
@@ -5,7 +5,7 @@ export const easeOutQuart = 'cubic-bezier(0.25, 1, 0.5, 1)';
 export const stageInCenter = keyframes`
   0% {
     transform: scale(.5);
-    opacity: .5;
+    opacity: 0;
   }
 
   100% {
@@ -22,7 +22,7 @@ export const stageOutCenter = keyframes`
 
   100% {
     transform: scale(.5);
-    opacity: .5;
+    opacity: 0;
   }
 `;
 

--- a/src/components/style/animations.js
+++ b/src/components/style/animations.js
@@ -2,7 +2,7 @@ import { keyframes } from 'styled-components';
 
 export const easeOutQuart = 'cubic-bezier(0.25, 1, 0.5, 1)';
 
-export const stageInAnimation = keyframes`
+export const stageInCenter = keyframes`
   0% {
     transform: scale(.5);
     opacity: .5;
@@ -14,7 +14,7 @@ export const stageInAnimation = keyframes`
   }
 `;
 
-export const stageOutAnimation = keyframes`
+export const stageOutCenter = keyframes`
   0% {
     transform: scale(1);
     opacity: 1;
@@ -22,6 +22,30 @@ export const stageOutAnimation = keyframes`
 
   100% {
     transform: scale(.5);
+    opacity: .5;
+  }
+`;
+
+export const stageInRight = keyframes`
+  0% {
+    transform: translateX(200px);
+    opacity: .5;
+  }
+
+  100% {
+    transform: translateX(0);
+    opacity: 1;
+  }
+`;
+
+export const stageOutRight = keyframes`
+  0% {
+    transform: translateX(0);
+    opacity: 1;
+  }
+
+  100% {
+    transform: translateX(200px);
     opacity: .5;
   }
 `;

--- a/src/components/style/animations.js
+++ b/src/components/style/animations.js
@@ -29,7 +29,7 @@ export const stageOutCenter = keyframes`
 export const stageInRight = keyframes`
   0% {
     transform: translateX(200px);
-    opacity: .5;
+    opacity: 0;
   }
 
   100% {
@@ -46,6 +46,6 @@ export const stageOutRight = keyframes`
 
   100% {
     transform: translateX(200px);
-    opacity: .5;
+    opacity: 0;
   }
 `;

--- a/src/components/style/animations.js
+++ b/src/components/style/animations.js
@@ -49,3 +49,27 @@ export const stageOutRight = keyframes`
     opacity: 0;
   }
 `;
+
+export const stageInTop = keyframes`
+  0% {
+    transform: translateY(-200px);
+    opacity: 0;
+  }
+
+  100% {
+    transform: translateY(0);
+    opacity: 1;
+  }
+`;
+
+export const fadeOut = keyframes`
+  0% {
+    transform: scale(1) translateY(0);
+    opacity: 1;
+  }
+
+  100% {
+    transform: scale(1.05) translateY(-10px);
+    opacity: 0;
+  }
+`;

--- a/src/documentation/examples/AnimationWrapper/AnimationWrapper.jsx
+++ b/src/documentation/examples/AnimationWrapper/AnimationWrapper.jsx
@@ -1,32 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import AnimationWrapper from '@bufferapp/ui/AnimationWrapper';
 import Text from '@bufferapp/ui/Text';
-import { keyframes } from 'styled-components';
 
-const stageInAnimation = keyframes`
-  0% {
-    transform: scale(.5);
-    opacity: .5;
-  }
-
-  100% {
-    transform: scale(1);
-    opacity: 1;
-  }
-`;
-
-const stageOutAnimation = keyframes`
-  0% {
-    transform: scale(1);
-    opacity: 1;
-  }
-
-  100% {
-    transform: scale(.5);
-    opacity: .5;
-  }
-`;
-
+import { stageInAnimation, stageOutAnimation } from '@bufferapp/ui/style/animations';
 
 /** AnimationWrapper Example */
 export default function ExampleSimpleModal() {

--- a/src/documentation/examples/AnimationWrapper/AnimationWrapper.jsx
+++ b/src/documentation/examples/AnimationWrapper/AnimationWrapper.jsx
@@ -1,0 +1,79 @@
+import React, { useState, useEffect } from 'react';
+import AnimationWrapper from '@bufferapp/ui/AnimationWrapper';
+import Text from '@bufferapp/ui/Text';
+import { keyframes } from 'styled-components';
+
+const stageInAnimation = keyframes`
+  0% {
+    transform: scale(.5);
+    opacity: 0;
+  }
+
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+`;
+
+const stageOutAnimation = keyframes`
+  0% {
+    transform: scale(1);
+    opacity: 1;
+  }
+
+  100% {
+    transform: scale(.5);
+    opacity: 0;
+  }
+`;
+
+
+/** AnimationWrapper Example */
+export default function ExampleSimpleModal() {
+  const [changed, setChanged] = useState(false);
+
+  useEffect(()=> {
+    setTimeout(()=> {
+      setChanged(!changed);
+    }, 2000)
+  }, [changed]);
+
+  return (
+    <div>
+      <AnimationWrapper stageInAnimation={stageInAnimation} stageOutAnimation={stageOutAnimation} duration={450}>
+        {!changed && (
+          <div style={{ width: '300px', padding: '30px', background: 'pink' }}>
+            <Text type="p">
+              There is a theory which states that if ever anyone discovers
+              exactly what the Universe is for and why it is here, it will
+              instantly disappear and be replaced by something even more bizarre
+              and inexplicable.
+            </Text>
+          </div>
+        )}
+        {changed && (
+          <div style={{ width: '200px', padding: '30px', background: 'paleturquoise' }}>
+            <Text type="p">
+              Ah-ah, ah!
+              <br />
+              Ah-ah, ah!
+              <br />
+              <br />
+              We come from the land of the ice and snow
+              <br />
+              From the midnight sun where the hot springs flow
+              <br />
+              The hammer of the gods
+              <br />
+              Will drive our ships to new lands
+              <br />
+              To fight the horde, sing and cry
+              <br />
+              Valhalla, I am coming
+            </Text>
+          </div>
+        )}
+      </AnimationWrapper>
+    </div>
+  );
+}

--- a/src/documentation/examples/AnimationWrapper/AnimationWrapper.jsx
+++ b/src/documentation/examples/AnimationWrapper/AnimationWrapper.jsx
@@ -6,7 +6,7 @@ import { keyframes } from 'styled-components';
 const stageInAnimation = keyframes`
   0% {
     transform: scale(.5);
-    opacity: 0;
+    opacity: .5;
   }
 
   100% {
@@ -23,7 +23,7 @@ const stageOutAnimation = keyframes`
 
   100% {
     transform: scale(.5);
-    opacity: 0;
+    opacity: .5;
   }
 `;
 

--- a/src/documentation/examples/AnimationWrapper/AnimationWrapperHook.jsx
+++ b/src/documentation/examples/AnimationWrapper/AnimationWrapperHook.jsx
@@ -1,10 +1,10 @@
 import React, { useState, useEffect } from 'react';
-import AnimationWrapper from '@bufferapp/ui/AnimationWrapper';
+import { useAnimation } from '@bufferapp/ui/AnimationWrapper';
 import Text from '@bufferapp/ui/Text';
 
-import { stageInCenter, stageOutCenter } from '@bufferapp/ui/style/animations';
+import { stageInTop, stageOutRight } from '@bufferapp/ui/style/animations';
 
-/** AnimationWrapper Example */
+/** useAnimation hook example */
 export default function ExampleSimpleModal() {
   const [changed, setChanged] = useState(false);
 
@@ -14,9 +14,15 @@ export default function ExampleSimpleModal() {
     }, 2000)
   }, [changed]);
 
+  const { AnimationWrapper, animationProps } = useAnimation({
+    stageInAnimation: stageInTop,
+    stageOutAnimation: stageOutRight,
+    duration: 450,
+  })
+
   return (
     <div>
-      <AnimationWrapper stageInAnimation={stageInCenter} stageOutAnimation={stageOutCenter} duration={450}>
+      <AnimationWrapper {...animationProps}>
         {!changed && (
           <div style={{ width: '300px', padding: '30px', background: 'pink' }}>
             <Text type="p">

--- a/src/documentation/examples/SimpleModal/SimpleModal.jsx
+++ b/src/documentation/examples/SimpleModal/SimpleModal.jsx
@@ -6,6 +6,7 @@ import Button from '@bufferapp/ui/Button';
 /** SimpleModal Example */
 export default function ExampleSimpleModal() {
   const [modalOpen, openModal] = useState(false);
+  const [changed, setChanged] = useState(false);
   return (
     <div>
       <Button
@@ -16,22 +17,42 @@ export default function ExampleSimpleModal() {
         label="Bring the modal!"
       />
       {modalOpen && (
-        <SimpleModal closeAction={() => openModal(false)}>
-          <div style={{ width: '300px' }}>
-            <Text type="p">
-              There is a theory which states that if ever anyone discovers
-              exactly what the Universe is for and why it is here, it will
-              instantly disappear and be replaced by something even more bizarre
-              and inexplicable.
-            </Text>
-            <button type="button">merp</button>
-            <a href="#/merp">booo</a>
-            <button type="button">weeee</button>
-            {// eslint-disable-next-line
-              <div tabIndex="0">Hello world i'm a focusable div</div>}
-          </div>
-        </SimpleModal>
-      )}
+        <SimpleModal closeAction={() => { openModal(false); setChanged(false); }}>
+          {!changed && (
+            <div style={{ width: '300px', padding: '30px' }}>
+              <Text type="p">
+                There is a theory which states that if ever anyone discovers
+                exactly what the Universe is for and why it is here, it will
+                instantly disappear and be replaced by something even more bizarre
+                and inexplicable.
+              </Text>
+              <button type="button" onClick={() => setChanged(true)}>change content</button>
+            </div>
+          )}
+          {changed && (
+            <div style={{ width: '200px', padding: '30px' }}>
+              <Text type="p">
+                Ah-ah, ah!
+                <br />
+                Ah-ah, ah!
+                <br />
+                <br />
+                We come from the land of the ice and snow
+                <br />
+                From the midnight sun where the hot springs flow
+                <br />
+                The hammer of the gods
+                <br />
+                Will drive our ships to new lands
+                <br />
+                To fight the horde, sing and cry
+                <br />
+                Valhalla, I am coming
+              </Text>
+              <button type="button" onClick={() => setChanged(false)}>back</button>
+            </div>
+          )}
+        </SimpleModal>)}
     </div>
   );
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add the `AnimationWrapper` component to handle stage-in and stage-out animations on content change.

## Description
<!--- Describe your changes in detail -->
This can be used as a simple wrapper around rendering components to smoothly animate the transition between content states, for example, it is used in the `SimplaModal` to show a card change animation when re-rendering the card content.

### The lifecycle of the animation is the following:
- runs the `stage-in` animation on initial rendering

- on children changes it
1. detects the content change
2. pause the DOM mutation
3. runs the stage-out animation
4. apply DOM changes (re-render)
5.  and finally runs the `stage-in` animation.
- on dismiss it:
1. runs the `stage-out` animation
3. stop rendering the children 
2. run the `onDismiss` callback 

## Motivation and Context
Small transitional animations enhance the user experience and give the feeling of a more polished product. 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):
The `AnimationWrapper` is used in the following components:

- SimpleModal
![aninmate modal](https://user-images.githubusercontent.com/992920/116328921-ef73e580-a77e-11eb-875e-2a058c58f4f3.gif)

- Notification
![animate notification](https://user-images.githubusercontent.com/992920/116329209-acfed880-a77f-11eb-8d33-25c84440a4f6.gif)


- Notice
![animate notice](https://user-images.githubusercontent.com/992920/116329165-8b9dec80-a77f-11eb-85b1-1a1c92e0bba8.gif)



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style and guidelines of this project. <!--- Link to Standards file coming soon. -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the **CHANGELOG** document.
- [ ] I have added tests to cover my changes.
- [x] I have performed a self-review of my own code
- [x] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] All new and existing tests passed.
- [ ] I have performed the accessibility audit of my UI changes according to the accessibility doc. <!--- Link to Accessibility Standards file coming soon. -->
- [ ] [Buffer Engineers] Someone from the Design team reviewed and approved my changes
- [ ] [Buffer Engineers] I have notified the BDS team of my changes in the #proj-design-system Slack channel
