### PR TITLE
Fix Segmented Control padding

### DIFF
--- a/src/components/SegmentedControl/Option/style.js
+++ b/src/components/SegmentedControl/Option/style.js
@@ -32,8 +32,13 @@ export const OptionStyled = styled.div`
   cursor: ${props => props.disabled ? 'not-allowed' : 'pointer'};
   border-radius: ${borderRadius};
   margin-right: 4px;
-  border: 1px solid ${transparent};
   transition: all 0.1s ease-out;
+
+  border: ${props => {
+    if (props.selected) return `1px solid ${blueLightest}`;
+    if (props.selected) return `1px solid ${gray}`;
+    return `1px solid ${transparent}`;
+  }};
 
   color: ${props => {
     if (props.selected) return blue;
@@ -47,9 +52,9 @@ export const OptionStyled = styled.div`
   }};
 
   padding: ${props => {
-    if (props.size === 'large') return '12px';
-    if (props.size === 'small') return '4px 8px';
-    return '8px';
+    if (props.size === 'large') return '11px';
+    if (props.size === 'small') return '3px 7px';
+    return '7px';
   }};
 
   &:last-child {

--- a/src/components/SegmentedControl/style.js
+++ b/src/components/SegmentedControl/style.js
@@ -6,6 +6,6 @@ export const Container = styled.div`
   display: flex;
   border: 1px solid ${gray};
   border-radius: ${borderRadius};
-  padding: 4px;
+  padding: 3px;
   background-color: ${white};
 `

--- a/src/documentation/markdown/GettingStarted/CHANGELOG.md
+++ b/src/documentation/markdown/GettingStarted/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [5.68.1] - 2021-07-19
+- Fix Segmented Control component padding
+
 ## [5.68.0] - 2021-07-13
 - Create new Segment control component
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail --> 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Discrepancies were found in Segmented Control sizes. The designs use inner border instead of adding a px to the outside. There is also a border around the options set to transparent that is given color when in a focus state. The borders around the two components collectively added a total of 4px extra to the height. This PR reduces the parent component and option component padding to compensate for the borders.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style and guidelines of this project. <!--- Link to Standards file coming soon. -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the **CHANGELOG** document.
- [ ] I have added tests to cover my changes.
- [x] I have performed a self-review of my own code
- [x] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] All new and existing tests passed.
- [ ] I have performed the accessibility audit of my UI changes according to the accessibility doc. <!--- Link to Accessibility Standards file coming soon. -->
- [ ] [Buffer Engineers] Someone from the Design team reviewed and approved my changes
- [ ] [Buffer Engineers] I have notified the BDS team of my changes in the #proj-design-system Slack channel
