### PR TITLE
fix: Tag hover text color

### DIFF
--- a/src/components/Tag/style.js
+++ b/src/components/Tag/style.js
@@ -12,4 +12,8 @@ export const Tag = styled.span`
   border-radius: 100px;
   color: ${(props) => textColors[props.textColor]};
   background-color: ${(props) => Colors[props.color]};
+
+  &:hover {
+    color: ${(props) => textColors[props.textColor]};
+  }
 `;

--- a/src/documentation/markdown/GettingStarted/CHANGELOG.md
+++ b/src/documentation/markdown/GettingStarted/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [5.69.1] - 2021-07-27
+- Fix :hover text color for Tag component
+
+## [5.69.0] - 2021-07-27
+- Add new Tag component
+
+## [5.68.3] - 2021-07-27
+- Added Canva, Pin and Title Icon
+- Added Add Icon example
+
 ## [5.68.2] - 2021-07-19
 - Fix Segmented Control component padding
 


### PR DESCRIPTION
## Description
Fix the color of the text inside `Tag` component when it's used in a hoverable element.

_Not hovered_:
<img width="355" alt="Screenshot 2021-07-27 at 08 55 58" src="https://user-images.githubusercontent.com/2612865/127109604-6b80baba-2bfc-48dc-af5a-3c7f1ddc4a23.png">

_Hovered:_
<img width="347" alt="Screenshot 2021-07-27 at 08 56 03" src="https://user-images.githubusercontent.com/2612865/127109608-f942136a-af0b-461f-80d1-766bce4b849f.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style and guidelines of this project. <!--- Link to Standards file coming soon. -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have updated the **CHANGELOG** document.
- [ ] I have added tests to cover my changes.
- [X] I have performed a self-review of my own code
- [X] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] All new and existing tests passed.
- [ ] I have performed the accessibility audit of my UI changes according to the accessibility doc. <!--- Link to Accessibility Standards file coming soon. -->
- [ ] [Buffer Engineers] Someone from the Design team reviewed and approved my changes
- [ ] [Buffer Engineers] I have notified the BDS team of my changes in the #proj-design-system Slack channel
