### PR TITLE
[PUB-3612] Adjust Notice styles

### DIFF
--- a/src/components/Notice/Notice.jsx
+++ b/src/components/Notice/Notice.jsx
@@ -32,6 +32,7 @@ const NoticeWrapper = styled.div`
   display: flex;
   justify-content: flex-start;
   position: relative;
+  width: 100%;
 `;
 
 const WarningIcon = styled(Warning)`
@@ -58,7 +59,7 @@ const CloseButton = styled.button`
   }
 `;
 
-function Notice({ children, dismiss, type }) {
+function Notice({ children, dismiss, type, className }) {
   const { AnimationWrapper, dismiss:dismissAnimationWrapper, animationProps } = useAnimation({
     justify: 'flex-end',
     stageInAnimation: stageInRight,
@@ -68,7 +69,7 @@ function Notice({ children, dismiss, type }) {
 
   return (
     <AnimationWrapper {...animationProps}>
-      <NoticeWrapper type={type} dismiss={dismiss}>
+      <NoticeWrapper type={type} dismiss={dismiss} className={className}>
         {type === 'warning' && <WarningIcon />}
         {children}
         {dismiss && (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Add width: 100% to Notice
- Add className to be able to extend styles using styled-components

## Motivation and Context
With the animation wrapper around the Notice component, and a justify-content: flex-end, the Notice ends up always in the right side. I've added the width: 100% to the Notice so it relies on the parent's width.
<img width="1405" alt="Screenshot 2021-08-02 at 12 03 02" src="https://user-images.githubusercontent.com/16758464/127873321-6b789f48-f037-468a-9bc2-bed120d94ea5.png">

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://buffer.atlassian.net/browse/PUB-3612

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style and guidelines of this project. <!--- Link to Standards file coming soon. -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the **CHANGELOG** document.
- [ ] I have added tests to cover my changes.
- [x] I have performed a self-review of my own code
- [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] All new and existing tests passed.
- [ ] I have performed the accessibility audit of my UI changes according to the accessibility doc. <!--- Link to Accessibility Standards file coming soon. -->
- [ ] [Buffer Engineers] Someone from the Design team reviewed and approved my changes
- [ ] [Buffer Engineers] I have notified the BDS team of my changes in the #proj-design-system Slack channel
