### PR TITLE
Add tag property to MenuItem in DropdownMenu

### DIFF
--- a/src/components/DropdownMenu/ButtonItem/ButtonItem.jsx
+++ b/src/components/DropdownMenu/ButtonItem/ButtonItem.jsx
@@ -49,10 +49,10 @@ export default class ButtonItem extends React.Component {
       case this.keyCode.SPACE:
       case this.keyCode.RETURN: {
         const { item: { onItemClick } } = this.props;
-        if (onItemClick) {
-          onItemClick();
-          flag = true;
-        }
+          if (onItemClick) {
+            onItemClick();
+            flag = true;
+          }
         }
         break;
       default:
@@ -77,7 +77,7 @@ export default class ButtonItem extends React.Component {
 
   render() {
     const {
-      item: { type, title, onItemClick, icon, selected, disabled, colors },
+      item: { type, title, onItemClick, icon, selected, disabled, colors, tag },
       ariaHaspopup,
     } = this.props;
     const hasIcon = !!icon || !!selected;
@@ -102,6 +102,7 @@ export default class ButtonItem extends React.Component {
         {selected && <CheckmarkIcon color={green} />}
         {icon || null}
         <ButtonLabel hasIcon={hasIcon} type={type}>{title}</ButtonLabel>
+        {tag || null}
       </ButtonItemStyled>
     );
   }

--- a/src/documentation/examples/DropdownMenu/DropdownMenu.jsx
+++ b/src/documentation/examples/DropdownMenu/DropdownMenu.jsx
@@ -53,14 +53,10 @@ const menuItems = [
   },
   {
     id: '6',
-    title: (
-      <span>
-        Canva
-        <Tag>New</Tag>
-      </span>
-    ),
+    title: 'Canva',
     colors: { iconHover: canvaLight },
     icon: <Canva color={canva} />,
+    tag: <Tag>New</Tag>,
     onItemClick: () => console.info('Canva'),
   },
 ];


### PR DESCRIPTION
## Description
This PR adds a new property `tag` to the MenuItem in the Dropdown Menu component. It replicates the idea of the `icon` property.

## Motivation and Context
The motivation behind is to remove the warning

> checkPropTypes.js:20 Warning: Failed prop type: Invalid prop `item.title` of type `object` supplied to `ButtonItem`, expected `string`.

when passing an object instead of a string.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style and guidelines of this project. <!--- Link to Standards file coming soon. -->
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have updated the **CHANGELOG** document.
- [ ] I have added tests to cover my changes.
- [X] I have performed a self-review of my own code
- [X] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] All new and existing tests passed.
- [ ] I have performed the accessibility audit of my UI changes according to the accessibility doc. <!--- Link to Accessibility Standards file coming soon. -->
- [ ] [Buffer Engineers] Someone from the Design team reviewed and approved my changes
- [ ] [Buffer Engineers] I have notified the BDS team of my changes in the #proj-design-system Slack channel
