### PR TITLE
[PUB-3784] Fix/search field breaks multi select

### DIFF
--- a/src/components/Select/Select.jsx
+++ b/src/components/Select/Select.jsx
@@ -345,16 +345,16 @@ export default class Select extends React.Component {
 
     const { startingWith, including } = items.reduce((filtered, item) => {
       if (item[searchFiled].toLowerCase().startsWith(searchValue.toLowerCase())) {
-        return {...filtered, startingWith: [...filtered.startingWith, {...item, selected: 
+        return {...filtered, startingWith: [...filtered.startingWith, {...item, selected:
           this.findItemInState(item) && this.findItemInState(item).selected,
         }]}
-      } 
+      }
       if (item[searchFiled].toLowerCase().includes(searchValue.toLowerCase())) {
-        return {...filtered, including: [...filtered.including, {...item, selected: 
+        return {...filtered, including: [...filtered.including, {...item, selected:
           this.findItemInState(item) && this.findItemInState(item).selected,
         }]}
-      } 
-      
+      }
+
       return {...filtered};
     }, { startingWith: [], including: []});
 
@@ -362,7 +362,7 @@ export default class Select extends React.Component {
 
     this.setState({
       items: arrayFinal,
-      isFiltering: true,
+      isFiltering: !!searchValue,
       searchValue,
     });
   };

--- a/src/components/Select/Select.jsx
+++ b/src/components/Select/Select.jsx
@@ -52,7 +52,7 @@ export default class Select extends React.Component {
       !Select.sameItems(props.items, state.items) &&
       !state.isFiltering
     ) {
-      return { items: props.items };
+      return { items: props.items, selectedItems: props.items };
     }
     return null;
   }

--- a/src/components/Select/Select.jsx
+++ b/src/components/Select/Select.jsx
@@ -333,7 +333,7 @@ export default class Select extends React.Component {
 
   onSearchChange = searchValue => {
     const { items, keyMap } = this.props;
-    const searchFiled = keyMap ? keyMap.title : 'title';
+    const searchField = keyMap ? keyMap.title : 'title';
 
     // first, filter the items in the props that we get from the parent
 
@@ -344,12 +344,12 @@ export default class Select extends React.Component {
     // and we need to check there to see, for each item, if its selected
 
     const { startingWith, including } = items.reduce((filtered, item) => {
-      if (item[searchFiled].toLowerCase().startsWith(searchValue.toLowerCase())) {
+      if (item[searchField].toLowerCase().startsWith(searchValue.toLowerCase())) {
         return {...filtered, startingWith: [...filtered.startingWith, {...item, selected:
           this.findItemInState(item) && this.findItemInState(item).selected,
         }]}
       }
-      if (item[searchFiled].toLowerCase().includes(searchValue.toLowerCase())) {
+      if (item[searchField].toLowerCase().includes(searchValue.toLowerCase())) {
         return {...filtered, including: [...filtered.including, {...item, selected:
           this.findItemInState(item) && this.findItemInState(item).selected,
         }]}

--- a/src/components/Select/Select.test.js
+++ b/src/components/Select/Select.test.js
@@ -106,6 +106,30 @@ describe('SomeComponent component', () => {
     }]);
   });
 
+  it('onSearchChange: should only set isFiltering state to true if search value is provided', () => {
+    const wrapper = shallow(<Select
+      onSelectClick={() => true}
+      items={[
+        {
+          id: '1', title: 'Testing',
+        },
+        {
+          id: '2', title: '123',
+        },
+      ]}
+      label="Select"
+    />);
+    const instance = wrapper.instance();
+
+    // Set isFiltering to true because searchValue has a value
+    instance.onSearchChange('Test');
+    expect(wrapper.state().isFiltering).toEqual(true);
+
+    // Set isFiltering to false because searchValue has no value
+    instance.onSearchChange('');
+    expect(wrapper.state().isFiltering).toEqual(false);
+  });
+
   it('onSearchChange: should re-order search in state based on matches with startsWith, then includes', () => {
     const wrapper = shallow(<Select
       onSelectClick={() => true}

--- a/src/documentation/examples/Select/SelectWithSelectAll.jsx
+++ b/src/documentation/examples/Select/SelectWithSelectAll.jsx
@@ -1,0 +1,51 @@
+import React, { useState } from 'react';
+import Select from '@bufferapp/ui/Select';
+import { Flag } from '@bufferapp/ui/Icon';
+
+const data = [
+  { _id: '1', name: 'First', selected: true },
+  { _id: '2', name: 'Second', selected: true },
+  { _id: '3', name: 'Third', selected: true },
+  { _id: '4', name: 'Fourth', selected: true },
+  { _id: '5', name: 'Fifth', selected: true },
+];
+
+/** With Select All option */
+export default function ExampleSelectWithSelectAll() {
+  const [items, setItems] = useState(data);
+
+  const handleClick = (option) => {
+    // If 'All' item is clicked, either select or deselect all items
+    if (option.name === 'All') {
+      const newSelectedValue = !items.every(item => item.selected === true);
+      setItems(items.map(item => ({ ...item, selected: newSelectedValue })));
+
+    } else { // If any other item is clicked, either select or deselect only that item
+      setItems(items.map(item => {
+        if (item._id === option._id) return { ...item, selected: !item.selected };
+        return item;
+      }));
+    }
+  };
+
+  // Create the 'All' item and determine whether it should be marked as selected or not
+  const allItemsOption = {
+    _id: '0', name: 'All', selected: items.every(item => item.selected === true),
+  };
+
+  return (
+    <Select
+      onSelectClick={item => handleClick(item)}
+      label='Try Select All'
+      icon={<Flag color='white' />}
+      type='primary'
+      // hideSearch
+      multiSelect
+      keyMap={{
+        id: '_id',
+        title: 'name',
+      }}
+      items={[ allItemsOption, ...items ]}
+    />
+  );
+}

--- a/src/documentation/examples/Select/SelectWithSelectAll.jsx
+++ b/src/documentation/examples/Select/SelectWithSelectAll.jsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import Select from '@bufferapp/ui/Select';
-import { Flag } from '@bufferapp/ui/Icon';
 
 const data = [
   { _id: '1', name: 'First', selected: true },
@@ -37,9 +36,7 @@ export default function ExampleSelectWithSelectAll() {
     <Select
       onSelectClick={item => handleClick(item)}
       label='Try Select All'
-      icon={<Flag color='white' />}
       type='primary'
-      // hideSearch
       multiSelect
       keyMap={{
         id: '_id',

--- a/src/documentation/markdown/GettingStarted/CHANGELOG.md
+++ b/src/documentation/markdown/GettingStarted/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [5.75.1] - 2021-09-14
 
 ### Fixed
 - Select Component: Search field onBlur prevents getDerivedStateFromProps from running

--- a/src/documentation/markdown/GettingStarted/CHANGELOG.md
+++ b/src/documentation/markdown/GettingStarted/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- Select Component: Search field onBlur prevents getDerivedStateFromProps from running
+- Select Component: Set selectedItems to items prop in getDerivedStateFromProps
+
+### Added
+- Select example with a Select All option
+
 ## [5.75.0] - 2021-08-31
 - Add icon: Save
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- Only set `isFiltering` to `true` if `searchValue` has a value 
- Set `selectedItems` state to `items` prop in `getDerivedStateFromProps`
- Update `searchFiled` typo to `searchField`
- Add example of a Select with a Select All option
- Add test to ensure `isFiltering` state is being set correctly

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The `Select` component implements the `Search` component with `clearSearchOnBlur` set to `true`. Because the `Search` field is auto focused, the first click after opening the `Select` menu always runs the `Search` component's `onBlur` callback, which, in this case, is the `onSearchChange` method.

The `onSearchChange` method always sets `isFiltering` to `true`, even if the provided `searchValue` is an empty string, which is always the case when the `Search` field is being blurred because of the `clearSearchOnBlur` prop.

Whenever `isFiltering` is `true`, `getDerivedStateFromProps` will not update state. This causes items to update incorrectly if the `Search` field is present and the `items` prop changes.

This PR fixes this issue.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/22494582/133205216-c5e62d73-2823-4ed4-82bb-905dfc6d25c9.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style and guidelines of this project. <!--- Link to Standards file coming soon. -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the **CHANGELOG** document.
- [x] I have added tests to cover my changes.
- [x] I have performed a self-review of my own code
- [x] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] All new and existing tests passed.
- [x] I have performed the accessibility audit of my UI changes according to the accessibility doc. <!--- Link to Accessibility Standards file coming soon. -->
- [ ] [Buffer Engineers] Someone from the Design team reviewed and approved my changes
- [ ] [Buffer Engineers] I have notified the BDS team of my changes in the #proj-design-system Slack channel
