### PR TITLE
[PUB-3576] Revert renamed Search prop name

### DIFF
--- a/src/components/Search/Search.jsx
+++ b/src/components/Search/Search.jsx
@@ -40,8 +40,8 @@ export default class Search extends React.Component {
       placeholder,
       onClick,
       height,
-      resetOnBlur,
-      resetOnFocus,
+      clearSearchOnBlur,
+      clearSearchOnFocus,
     } = this.props;
 
     const { search } = this.state;
@@ -55,8 +55,8 @@ export default class Search extends React.Component {
           ref={inputRef => this.inputRef = inputRef}
           onChange={event => this.onChange(event)}
           onClick={onClick}
-          onBlur={resetOnBlur ? this.clearSearch : undefined}
-          onFocus={resetOnFocus ? this.clearSearch : undefined}
+          onBlur={clearSearchOnBlur ? this.clearSearch : undefined}
+          onFocus={clearSearchOnFocus ? this.clearSearch : undefined}
           height={height}
         />
       </SearchWrapper>
@@ -81,10 +81,10 @@ Search.propTypes = {
   height: PropTypes.string,
 
   /** Should the search clear on blur */
-  resetOnBlur: PropTypes.bool,
+  clearSearchOnBlur: PropTypes.bool,
 
   /** Should the search clear on focus */
-  resetOnFocus: PropTypes.bool,
+  clearSearchOnFocus: PropTypes.bool,
 
   /** Is onBlur event */
   onBlur: PropTypes.func
@@ -94,8 +94,8 @@ Search.defaultProps = {
   placeholder: '',
   height: 'tall',
   isOpen: false,
-  resetOnBlur: false,
-  resetOnFocus: false,
+  clearSearchOnBlur: false,
+  clearSearchOnFocus: false,
   onClick: () => {},
   onBlur: () => {}
 }

--- a/src/components/Search/__snapshots__/Search.spec.js.snap
+++ b/src/components/Search/__snapshots__/Search.spec.js.snap
@@ -1,5 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`jest-auto-snapshots > Search Matches snapshot when boolean prop "clearSearchOnBlur" is set to: "false" 1`] = `
+<ForwardRef(styled.div)>
+  <ForwardRef(styled.input)
+    height="jest-auto-snapshots String Fixture"
+    onChange={[Function]}
+    onClick={[MockFunction]}
+    onFocus={[Function]}
+    placeholder="jest-auto-snapshots String Fixture"
+    type="text"
+    value=""
+  />
+</ForwardRef(styled.div)>
+`;
+
+exports[`jest-auto-snapshots > Search Matches snapshot when boolean prop "clearSearchOnFocus" is set to: "false" 1`] = `
+<ForwardRef(styled.div)>
+  <ForwardRef(styled.input)
+    height="jest-auto-snapshots String Fixture"
+    onBlur={[Function]}
+    onChange={[Function]}
+    onClick={[MockFunction]}
+    placeholder="jest-auto-snapshots String Fixture"
+    type="text"
+    value=""
+  />
+</ForwardRef(styled.div)>
+`;
+
 exports[`jest-auto-snapshots > Search Matches snapshot when boolean prop "isOpen" is set to: "false" 1`] = `
 <ForwardRef(styled.div)>
   <ForwardRef(styled.input)
@@ -8,34 +36,6 @@ exports[`jest-auto-snapshots > Search Matches snapshot when boolean prop "isOpen
     onChange={[Function]}
     onClick={[MockFunction]}
     onFocus={[Function]}
-    placeholder="jest-auto-snapshots String Fixture"
-    type="text"
-    value=""
-  />
-</ForwardRef(styled.div)>
-`;
-
-exports[`jest-auto-snapshots > Search Matches snapshot when boolean prop "resetOnBlur" is set to: "false" 1`] = `
-<ForwardRef(styled.div)>
-  <ForwardRef(styled.input)
-    height="jest-auto-snapshots String Fixture"
-    onChange={[Function]}
-    onClick={[MockFunction]}
-    onFocus={[Function]}
-    placeholder="jest-auto-snapshots String Fixture"
-    type="text"
-    value=""
-  />
-</ForwardRef(styled.div)>
-`;
-
-exports[`jest-auto-snapshots > Search Matches snapshot when boolean prop "resetOnFocus" is set to: "false" 1`] = `
-<ForwardRef(styled.div)>
-  <ForwardRef(styled.input)
-    height="jest-auto-snapshots String Fixture"
-    onBlur={[Function]}
-    onChange={[Function]}
-    onClick={[MockFunction]}
     placeholder="jest-auto-snapshots String Fixture"
     type="text"
     value=""

--- a/src/components/Select/Select.jsx
+++ b/src/components/Select/Select.jsx
@@ -751,6 +751,6 @@ Select.defaultProps = {
   noResultsCustomMessage: 'No matches found',
   clearSearchOnBlur: false,
   searchInputProps: {
-    resetOnBlur: true,
+    clearSearchOnBlur: true,
   },
 };

--- a/src/documentation/markdown/GettingStarted/CHANGELOG.md
+++ b/src/documentation/markdown/GettingStarted/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [5.75.7] - 2021-09-27
+
+### Fixed
+- Search: Revert `resetOnBlur` prop to `clearSearchOnBlur` as renaming an existing prop is technically a breaking change
+
 ## [5.75.6] - 2021-09-22
 
 ### Fixed


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Revert a prop name that was renamed as changing an existing prop name is technically a breaking change

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style and guidelines of this project. <!--- Link to Standards file coming soon. -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the **CHANGELOG** document.
- [ ] I have added tests to cover my changes.
- [x] I have performed a self-review of my own code
- [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] All new and existing tests passed.
- [ ] I have performed the accessibility audit of my UI changes according to the accessibility doc. <!--- Link to Accessibility Standards file coming soon. -->
- [ ] [Buffer Engineers] Someone from the Design team reviewed and approved my changes
- [ ] [Buffer Engineers] I have notified the BDS team of my changes in the #proj-design-system Slack channel
