### PR TITLE
[PUB-3845] Add ability to hide specific items during search in Select component

### DIFF
--- a/src/components/Select/Select.jsx
+++ b/src/components/Select/Select.jsx
@@ -354,6 +354,7 @@ export default class Select extends React.Component {
   onSearchChange = searchValue => {
     const { items, keyMap } = this.props;
     const searchField = keyMap ? keyMap.title : 'title';
+    const isFiltering = !!searchValue;
 
     // first, filter the items in the props that we get from the parent
 
@@ -364,6 +365,9 @@ export default class Select extends React.Component {
     // and we need to check there to see, for each item, if its selected
 
     const { startingWith, including } = items.reduce((filtered, item) => {
+      const hideItemWhileSearching = isFiltering && !!item.hideOnSearch;
+      if (hideItemWhileSearching) return filtered;
+
       if (item[searchField].toLowerCase().startsWith(searchValue.toLowerCase())) {
         return {...filtered, startingWith: [...filtered.startingWith, {...item, selected:
           this.findItemInState(item) && this.findItemInState(item).selected,
@@ -382,7 +386,7 @@ export default class Select extends React.Component {
 
     this.setState({
       items: arrayFinal,
-      isFiltering: !!searchValue,
+      isFiltering,
       searchValue,
     });
   };
@@ -619,6 +623,8 @@ Select.propTypes = {
     PropTypes.shape({
       id: PropTypes.string,
       title: PropTypes.string,
+      /** If true, item will be hidden while searching */
+      hideOnSearch: PropTypes.bool,
     })
   ).isRequired,
 

--- a/src/components/Select/Select.test.js
+++ b/src/components/Select/Select.test.js
@@ -205,6 +205,61 @@ describe('Select component', () => {
     ]);
   });
 
+  it('onSearchChange: should exclude items from search if "hideOnSearch" property is true', () => {
+    const wrapper = shallow(<Select
+      onSelectClick={() => true}
+      items={[
+        {
+          id: '1', title: 'Open', hideOnSearch: true,
+        },
+        {
+          id: '2', title: 'Pending',
+        },
+        {
+          id: '3', title: 'Closed',
+        },
+      ]}
+      label="Select"
+    />);
+    const instance = wrapper.instance();
+    instance.onSearchChange('Pen');
+    expect(wrapper.state().items).toEqual([
+      {
+        id: '2', title: 'Pending',
+      }
+    ]);
+  });
+
+  it('onSearchChange: "hideOnSearch" property should only hide item if search value is provided', () => {
+    const wrapper = shallow(<Select
+      onSelectClick={() => true}
+      items={[
+        {
+          id: '1', title: 'Open', hideOnSearch: true,
+        },
+        {
+          id: '2', title: 'Pending',
+        },
+        {
+          id: '3', title: 'Closed',
+        },
+      ]}
+      label="Select"
+    />);
+    const instance = wrapper.instance();
+    instance.onSearchChange('');
+    expect(wrapper.state().items).toEqual([
+      {
+        id: '1', title: 'Open', hideOnSearch: true,
+      },
+      {
+        id: '2', title: 'Pending',
+      },
+      {
+        id: '3', title: 'Closed',
+      },
+    ]);
+  });
 
   it('updateHoveredItemPosition: should update hoveredItem in state', () => {
     const wrapper = shallow(<Select onSelectClick={() => true} items={[]} label="Select" />);

--- a/src/components/Select/__snapshots__/Select.spec.js.snap
+++ b/src/components/Select/__snapshots__/Select.spec.js.snap
@@ -38,6 +38,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when array prop "hotKeys"
         hovered={false}
         item={
           Object {
+            "hideOnSearch": true,
             "id": "jest-auto-snapshots String Fixture",
             "title": "jest-auto-snapshots String Fixture",
           }
@@ -95,6 +96,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when array prop "hotKeys"
         hovered={false}
         item={
           Object {
+            "hideOnSearch": true,
             "id": "jest-auto-snapshots String Fixture",
             "title": "jest-auto-snapshots String Fixture",
           }
@@ -152,6 +154,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when array prop "items" h
         hovered={false}
         item={
           Object {
+            "hideOnSearch": true,
             "id": "jest-auto-snapshots String Fixture",
             "title": "jest-auto-snapshots String Fixture",
           }
@@ -209,6 +212,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "capita
         hovered={false}
         item={
           Object {
+            "hideOnSearch": true,
             "id": "jest-auto-snapshots String Fixture",
             "title": "jest-auto-snapshots String Fixture",
           }
@@ -266,6 +270,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "clearS
         hovered={false}
         item={
           Object {
+            "hideOnSearch": true,
             "id": "jest-auto-snapshots String Fixture",
             "title": "jest-auto-snapshots String Fixture",
           }
@@ -324,6 +329,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "disabl
         hovered={false}
         item={
           Object {
+            "hideOnSearch": true,
             "id": "jest-auto-snapshots String Fixture",
             "title": "jest-auto-snapshots String Fixture",
           }
@@ -381,6 +387,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "fullWi
         hovered={false}
         item={
           Object {
+            "hideOnSearch": true,
             "id": "jest-auto-snapshots String Fixture",
             "title": "jest-auto-snapshots String Fixture",
           }
@@ -438,6 +445,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "hasCus
         hovered={false}
         item={
           Object {
+            "hideOnSearch": true,
             "id": "jest-auto-snapshots String Fixture",
             "title": "jest-auto-snapshots String Fixture",
           }
@@ -495,6 +503,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "hasIco
         hovered={false}
         item={
           Object {
+            "hideOnSearch": true,
             "id": "jest-auto-snapshots String Fixture",
             "title": "jest-auto-snapshots String Fixture",
           }
@@ -552,6 +561,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "hideSe
         hovered={false}
         item={
           Object {
+            "hideOnSearch": true,
             "id": "jest-auto-snapshots String Fixture",
             "title": "jest-auto-snapshots String Fixture",
           }
@@ -609,6 +619,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "isInpu
         hovered={false}
         item={
           Object {
+            "hideOnSearch": true,
             "id": "jest-auto-snapshots String Fixture",
             "title": "jest-auto-snapshots String Fixture",
           }
@@ -666,6 +677,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "isOpen
         hovered={false}
         item={
           Object {
+            "hideOnSearch": true,
             "id": "jest-auto-snapshots String Fixture",
             "title": "jest-auto-snapshots String Fixture",
           }
@@ -715,6 +727,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "isSpli
         hovered={false}
         item={
           Object {
+            "hideOnSearch": true,
             "id": "jest-auto-snapshots String Fixture",
             "title": "jest-auto-snapshots String Fixture",
           }
@@ -772,6 +785,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "multiS
         hovered={false}
         item={
           Object {
+            "hideOnSearch": true,
             "id": "jest-auto-snapshots String Fixture",
             "title": "jest-auto-snapshots String Fixture",
           }
@@ -829,6 +843,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "select
         hovered={false}
         item={
           Object {
+            "hideOnSearch": true,
             "id": "jest-auto-snapshots String Fixture",
             "title": "jest-auto-snapshots String Fixture",
           }
@@ -886,6 +901,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "shortc
         hovered={false}
         item={
           Object {
+            "hideOnSearch": true,
             "id": "jest-auto-snapshots String Fixture",
             "title": "jest-auto-snapshots String Fixture",
           }
@@ -943,6 +959,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when passed all props 1`]
         hovered={false}
         item={
           Object {
+            "hideOnSearch": true,
             "id": "jest-auto-snapshots String Fixture",
             "title": "jest-auto-snapshots String Fixture",
           }
@@ -982,6 +999,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when passed only required
     items={
       Array [
         Object {
+          "hideOnSearch": true,
           "id": "jest-auto-snapshots String Fixture",
           "title": "jest-auto-snapshots String Fixture",
         },
@@ -1009,6 +1027,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when passed only required
         hovered={false}
         item={
           Object {
+            "hideOnSearch": true,
             "id": "jest-auto-snapshots String Fixture",
             "title": "jest-auto-snapshots String Fixture",
           }

--- a/src/documentation/markdown/GettingStarted/CHANGELOG.md
+++ b/src/documentation/markdown/GettingStarted/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [5.75.8]
 - Select: Set `hideOnSearch` property to true on items to hide them during search
 
 ## [5.75.7] - 2021-09-27

--- a/src/documentation/markdown/GettingStarted/CHANGELOG.md
+++ b/src/documentation/markdown/GettingStarted/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [Unreleased]
+- Select: Set `hideOnSearch` property to true on items to hide them during search
+
 ## [5.75.7] - 2021-09-27
 
 ### Fixed


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add the ability to specify a `hideOnSearch` property on items being passed to the Select component. If this value is set to true, the item will never be displayed as an available option during search.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix for ticket [PUB-3845](https://buffer.atlassian.net/browse/PUB-3845?atlOrigin=eyJpIjoiZTQ4ZDIxMzU3NTU3NDRkMzk1ODU3NDAyZWQxNzliMDQiLCJwIjoiaiJ9)

We need a "Select all" option for Calendar's Channel filter feature. 
This option should either always show at the top of the list while searching, regardless of the search value, or never show during search.

The simplest solution that also makes sense practically is to never show it while searching. The assumption is that users are searching for a specific channel and will usually not want to select all channels while in this state.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/22494582/135058762-3e226916-628f-43fa-bd3f-4f1bd44e1b44.png) ![image](https://user-images.githubusercontent.com/22494582/135058823-6d7a854b-16d5-4fe6-8cd0-69062dddd66c.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style and guidelines of this project. <!--- Link to Standards file coming soon. -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the **CHANGELOG** document.
- [x] I have added tests to cover my changes.
- [x] I have performed a self-review of my own code
- [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] All new and existing tests passed.
- [ ] I have performed the accessibility audit of my UI changes according to the accessibility doc. <!--- Link to Accessibility Standards file coming soon. -->
- [ ] [Buffer Engineers] Someone from the Design team reviewed and approved my changes
- [ ] [Buffer Engineers] I have notified the BDS team of my changes in the #proj-design-system Slack channel
