### PR TITLE
remove displayName from babel config

### DIFF
--- a/package.json
+++ b/package.json
@@ -197,9 +197,9 @@
           [
             "babel-plugin-styled-components",
             {
-              "displayName": true,
               "pure": true,
-              "namespace": "bufferapp/ui"
+              "namespace": "bufferapp/ui",
+              "minify": true
             }
           ]
         ]

--- a/src/documentation/markdown/GettingStarted/CHANGELOG.md
+++ b/src/documentation/markdown/GettingStarted/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [5.75.10] - 2021-10-04
+
+### Fixed
+- remove displayNames from babel config
+
 ## [5.75.9] - 2021-09-29
 
 ### Fixed


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
We had added displayNames to try avoiding class collisions between SP and the Navigator. [After the investigation](https://threads.com/34407290541), we noticed it's unnecessary and adds weight to be bundle. I also added back in minification as it was included in earlier versions. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
