### PR TITLE
Add option to disable animation on Notice component

### DIFF
--- a/src/components/AnimationWrapper/AnimationWrapper.jsx
+++ b/src/components/AnimationWrapper/AnimationWrapper.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import { easeOutQuart } from '../style/animations';
 
 const AnimationContainer = styled.div`
@@ -11,21 +11,15 @@ const AnimationContainer = styled.div`
   outline: none;
   width: 100%;
 
-  ${({ disableAnimation }) =>
-    !disableAnimation &&
-    css`
-      &.stageIn {
-        animation: ${({ duration }) => `${duration}ms`}
-          ${({ stageInAnimation }) => stageInAnimation}
-          ${({ easing }) => easing};
-      }
+  &.stageIn {
+    animation: ${({ duration }) => `${duration}ms`}
+      ${({ stageInAnimation }) => stageInAnimation} ${({ easing }) => easing};
+  }
 
-      &.stageOut {
-        animation: ${({ duration }) => `${duration}ms`}
-          ${({ stageOutAnimation }) => stageOutAnimation}
-          ${({ easing }) => easing};
-      }
-    `}
+  &.stageOut {
+    animation: ${({ duration }) => `${duration}ms`}
+      ${({ stageOutAnimation }) => stageOutAnimation} ${({ easing }) => easing};
+  }
 
   @media (prefers-reduced-motion) {
     &.stageIn,
@@ -45,7 +39,6 @@ const AnimationWrapper = ({
   stageInAnimation,
   stageOutAnimation,
   onDismiss,
-  disableAnimation,
 }) => {
   const [content, setContent] = useState(children);
   const [hasChanged, setHasChanged] = useState(false);
@@ -108,7 +101,6 @@ const AnimationWrapper = ({
       stageInAnimation={stageInAnimation}
       stageOutAnimation={stageOutAnimation}
       className={className}
-      disableAnimation={disableAnimation}
     >
       {!dismissed && content}
     </AnimationContainer>
@@ -125,7 +117,6 @@ AnimationWrapper.propTypes = {
   stageInAnimation: PropTypes.shape({}).isRequired,
   stageOutAnimation: PropTypes.shape({}).isRequired,
   onDismiss: PropTypes.func,
-  disableAnimation: PropTypes.bool,
 };
 
 AnimationWrapper.defaultProps = {
@@ -134,7 +125,6 @@ AnimationWrapper.defaultProps = {
   duration: 300,
   justify: 'center',
   easing: easeOutQuart,
-  disableAnimation: true,
   onDismiss: () => {},
 };
 

--- a/src/components/AnimationWrapper/AnimationWrapper.jsx
+++ b/src/components/AnimationWrapper/AnimationWrapper.jsx
@@ -6,19 +6,17 @@ import { easeOutQuart } from '../style/animations';
 const AnimationContainer = styled.div`
   animation-fill-mode: forwards;
   display: flex;
-  align-items: ${({ align }) => align};
-  justify-content: ${({ justify }) => justify};
+  align-items: ${({ align }) => align}}
+  justify-content: ${({ justify }) => justify}}
   outline: none;
   width: 100%;
 
   &.stageIn {
-    animation: ${({ duration }) => `${duration}ms`}
-      ${({ stageInAnimation }) => stageInAnimation} ${({ easing }) => easing};
+    animation: ${({ duration }) => `${duration}ms`} ${({ stageInAnimation }) => stageInAnimation} ${({ easing }) => easing};
   }
 
   &.stageOut {
-    animation: ${({ duration }) => `${duration}ms`}
-      ${({ stageOutAnimation }) => stageOutAnimation} ${({ easing }) => easing};
+    animation: ${({ duration }) => `${duration}ms`} ${({ stageOutAnimation }) => stageOutAnimation} ${({ easing }) => easing};
   }
 
   @media (prefers-reduced-motion) {
@@ -45,33 +43,33 @@ const AnimationWrapper = ({
   const [dismissed, setDismissed] = useState(false);
   const [animationLocked, setAnimationLocked] = useState(false);
   const [className, setClassName] = useState('stageIn');
-  const shouldUpdate = children !== content && !dismissing;
+  const shouldUpdate = children !== content && !dismissing
 
   function lockAnimationDuringStaging() {
-    setAnimationLocked(true);
+    setAnimationLocked(true)
     setTimeout(() => {
-      setAnimationLocked(false);
-    }, duration * 2);
+      setAnimationLocked(false)
+    }, duration * 2)
   }
 
   function stageIn() {
-    setClassName('stageIn');
+    setClassName('stageIn')
   }
 
   function stageOut() {
-    setClassName('stageOut');
+    setClassName('stageOut')
   }
 
   useEffect(() => {
     if (shouldUpdate) {
       setHasChanged(true);
       setTimeout(() => {
-        stageIn();
-        setContent(children);
-        setHasChanged(false);
-      }, duration);
+        stageIn()
+        setContent(children)
+        setHasChanged(false)
+      }, duration)
     }
-  }, [children]);
+  }, [children])
 
   useEffect(() => {
     if (dismissing) {
@@ -79,17 +77,17 @@ const AnimationWrapper = ({
       setTimeout(() => {
         setDismissed(true);
         onDismiss();
-      }, duration - 10);
+      }, duration - 10)
     }
-  }, [dismissing]);
+  }, [dismissing])
 
   useEffect(() => {
-    lockAnimationDuringStaging();
-  }, []);
+    lockAnimationDuringStaging()
+  }, [])
 
   if (!animationLocked && (hasChanged || dismissing)) {
-    stageOut();
-    lockAnimationDuringStaging();
+    stageOut()
+    lockAnimationDuringStaging()
   }
 
   return (

--- a/src/components/AnimationWrapper/AnimationWrapper.jsx
+++ b/src/components/AnimationWrapper/AnimationWrapper.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { easeOutQuart } from '../style/animations';
 
 const AnimationContainer = styled.div`
@@ -11,15 +11,21 @@ const AnimationContainer = styled.div`
   outline: none;
   width: 100%;
 
-  &.stageIn {
-    animation: ${({ duration }) => `${duration}ms`}
-      ${({ stageInAnimation }) => stageInAnimation} ${({ easing }) => easing};
-  }
+  ${({ disableAnimation }) =>
+    !disableAnimation &&
+    css`
+      &.stageIn {
+        animation: ${({ duration }) => `${duration}ms`}
+          ${({ stageInAnimation }) => stageInAnimation}
+          ${({ easing }) => easing};
+      }
 
-  &.stageOut {
-    animation: ${({ duration }) => `${duration}ms`}
-      ${({ stageOutAnimation }) => stageOutAnimation} ${({ easing }) => easing};
-  }
+      &.stageOut {
+        animation: ${({ duration }) => `${duration}ms`}
+          ${({ stageOutAnimation }) => stageOutAnimation}
+          ${({ easing }) => easing};
+      }
+    `}
 
   @media (prefers-reduced-motion) {
     &.stageIn,
@@ -39,6 +45,7 @@ const AnimationWrapper = ({
   stageInAnimation,
   stageOutAnimation,
   onDismiss,
+  disableAnimation,
 }) => {
   const [content, setContent] = useState(children);
   const [hasChanged, setHasChanged] = useState(false);
@@ -101,6 +108,7 @@ const AnimationWrapper = ({
       stageInAnimation={stageInAnimation}
       stageOutAnimation={stageOutAnimation}
       className={className}
+      disableAnimation={disableAnimation}
     >
       {!dismissed && content}
     </AnimationContainer>
@@ -117,6 +125,7 @@ AnimationWrapper.propTypes = {
   stageInAnimation: PropTypes.shape({}).isRequired,
   stageOutAnimation: PropTypes.shape({}).isRequired,
   onDismiss: PropTypes.func,
+  disableAnimation: PropTypes.bool,
 };
 
 AnimationWrapper.defaultProps = {
@@ -125,6 +134,7 @@ AnimationWrapper.defaultProps = {
   duration: 300,
   justify: 'center',
   easing: easeOutQuart,
+  disableAnimation: true,
   onDismiss: () => {},
 };
 

--- a/src/components/AnimationWrapper/AnimationWrapper.jsx
+++ b/src/components/AnimationWrapper/AnimationWrapper.jsx
@@ -6,17 +6,26 @@ import { easeOutQuart } from '../style/animations';
 const AnimationContainer = styled.div`
   animation-fill-mode: forwards;
   display: flex;
-  align-items: ${({ align }) => align}}
-  justify-content: ${({ justify }) => justify}}
+  align-items: ${({ align }) => align};
+  justify-content: ${({ justify }) => justify};
   outline: none;
   width: 100%;
 
   &.stageIn {
-    animation: ${({ duration }) => `${duration}ms`} ${({ stageInAnimation }) => stageInAnimation} ${({ easing }) => easing};
+    animation: ${({ duration }) => `${duration}ms`}
+      ${({ stageInAnimation }) => stageInAnimation} ${({ easing }) => easing};
   }
 
   &.stageOut {
-    animation: ${({ duration }) => `${duration}ms`} ${({ stageOutAnimation }) => stageOutAnimation} ${({ easing }) => easing};
+    animation: ${({ duration }) => `${duration}ms`}
+      ${({ stageOutAnimation }) => stageOutAnimation} ${({ easing }) => easing};
+  }
+
+  @media (prefers-reduced-motion) {
+    &.stageIn,
+    &.stageOut {
+      animation-name: dissolve;
+    }
   }
 `;
 
@@ -36,33 +45,33 @@ const AnimationWrapper = ({
   const [dismissed, setDismissed] = useState(false);
   const [animationLocked, setAnimationLocked] = useState(false);
   const [className, setClassName] = useState('stageIn');
-  const shouldUpdate = children !== content && !dismissing
+  const shouldUpdate = children !== content && !dismissing;
 
   function lockAnimationDuringStaging() {
-    setAnimationLocked(true)
+    setAnimationLocked(true);
     setTimeout(() => {
-      setAnimationLocked(false)
-    }, duration * 2)
+      setAnimationLocked(false);
+    }, duration * 2);
   }
 
   function stageIn() {
-    setClassName('stageIn')
+    setClassName('stageIn');
   }
 
   function stageOut() {
-    setClassName('stageOut')
+    setClassName('stageOut');
   }
 
   useEffect(() => {
     if (shouldUpdate) {
       setHasChanged(true);
       setTimeout(() => {
-        stageIn()
-        setContent(children)
-        setHasChanged(false)
-      }, duration)
+        stageIn();
+        setContent(children);
+        setHasChanged(false);
+      }, duration);
     }
-  }, [children])
+  }, [children]);
 
   useEffect(() => {
     if (dismissing) {
@@ -70,17 +79,17 @@ const AnimationWrapper = ({
       setTimeout(() => {
         setDismissed(true);
         onDismiss();
-      }, duration - 10)
+      }, duration - 10);
     }
-  }, [dismissing])
+  }, [dismissing]);
 
   useEffect(() => {
-    lockAnimationDuringStaging()
-  }, [])
+    lockAnimationDuringStaging();
+  }, []);
 
   if (!animationLocked && (hasChanged || dismissing)) {
-    stageOut()
-    lockAnimationDuringStaging()
+    stageOut();
+    lockAnimationDuringStaging();
   }
 
   return (

--- a/src/components/Notice/Notice.jsx
+++ b/src/components/Notice/Notice.jsx
@@ -59,7 +59,7 @@ const CloseButton = styled.button`
   }
 `;
 
-function Notice({ children, dismiss, type, className }) {
+function Notice({ children, dismiss, type, className, disableAnimation }) {
   const {
     AnimationWrapper,
     dismiss: dismissAnimationWrapper,
@@ -72,7 +72,7 @@ function Notice({ children, dismiss, type, className }) {
   });
 
   return (
-    <AnimationWrapper {...animationProps}>
+    <AnimationWrapper {...animationProps} disableAnimation={disableAnimation}>
       <NoticeWrapper type={type} dismiss={dismiss} className={className}>
         {type === 'warning' && <WarningIcon />}
         {children}
@@ -89,12 +89,14 @@ function Notice({ children, dismiss, type, className }) {
 Notice.propTypes = {
   children: PropTypes.node.isRequired,
   dismiss: PropTypes.func,
+  disableAnimation: PropTypes.bool,
   /** can be warning, note */
   type: PropTypes.string.isRequired,
 };
 
 Notice.defaultProps = {
   dismiss: null,
+  disableAnimation: false,
 };
 
 export default Notice;

--- a/src/components/Notice/Notice.jsx
+++ b/src/components/Notice/Notice.jsx
@@ -79,11 +79,11 @@ function Notice({ children, dismiss, type, className, disableAnimation }) {
     </NoticeWrapper>
   );
 
-  if (disableAnimation) {
-    return <>{noticeContent}</>;
+  if (!disableAnimation) {
+    return <AnimationWrapper {...animationProps}>{noticeContent}</AnimationWrapper>;
   }
 
-  return <AnimationWrapper {...animationProps}>{noticeContent}</AnimationWrapper>;
+  return <>{noticeContent}</>;
 }
 
 Notice.propTypes = {

--- a/src/components/Notice/Notice.jsx
+++ b/src/components/Notice/Notice.jsx
@@ -97,7 +97,6 @@ Notice.propTypes = {
 
 Notice.defaultProps = {
   dismiss: null,
-  disableAnimation: false
 };
 
 export default Notice;

--- a/src/components/Notice/Notice.jsx
+++ b/src/components/Notice/Notice.jsx
@@ -83,7 +83,7 @@ function Notice({ children, dismiss, type, className, disableAnimation }) {
     return <AnimationWrapper {...animationProps}>{noticeContent}</AnimationWrapper>;
   }
 
-  return <>{noticeContent}</>;
+  return <div>{noticeContent}</div>;
 }
 
 Notice.propTypes = {

--- a/src/components/Notice/Notice.jsx
+++ b/src/components/Notice/Notice.jsx
@@ -97,6 +97,7 @@ Notice.propTypes = {
 
 Notice.defaultProps = {
   dismiss: null,
+  disableAnimation: false
 };
 
 export default Notice;

--- a/src/components/Notice/Notice.jsx
+++ b/src/components/Notice/Notice.jsx
@@ -23,12 +23,12 @@ const colorMap = {
 };
 
 const NoticeWrapper = styled.div`
-  border: ${props => `1px solid ${colorMap[props.type].border}`};
-  color: ${props => colorMap[props.type].color};
-  background: ${props => colorMap[props.type].background};
+  border: ${(props) => `1px solid ${colorMap[props.type].border}`};
+  color: ${(props) => colorMap[props.type].color};
+  background: ${(props) => colorMap[props.type].background};
   border-radius: ${borderRadius};
   font-size: ${fontSize};
-  padding: 16px ${({ dismiss }) => dismiss ? '36px' : '16px' } 16px 16px;
+  padding: 16px ${({ dismiss }) => (dismiss ? '36px' : '16px')} 16px 16px;
   display: flex;
   justify-content: flex-start;
   position: relative;
@@ -43,7 +43,7 @@ const WarningIcon = styled(Warning)`
 `;
 
 const CloseButton = styled.button`
-  color: ${props => colorMap[props.type].color};
+  color: ${(props) => colorMap[props.type].color};
   border: 0;
   background: 0;
   padding: 0;
@@ -53,19 +53,23 @@ const CloseButton = styled.button`
   position: absolute;
   right: 16px;
   &:hover {
-    color: ${props => colorMap[props.type].color};
+    color: ${(props) => colorMap[props.type].color};
     opacity: 1;
     cursor: pointer;
   }
 `;
 
 function Notice({ children, dismiss, type, className }) {
-  const { AnimationWrapper, dismiss:dismissAnimationWrapper, animationProps } = useAnimation({
+  const {
+    AnimationWrapper,
+    dismiss: dismissAnimationWrapper,
+    animationProps,
+  } = useAnimation({
     justify: 'flex-end',
     stageInAnimation: stageInRight,
     stageOutAnimation: fadeOut,
     onDismiss: dismiss,
-  })
+  });
 
   return (
     <AnimationWrapper {...animationProps}>
@@ -73,10 +77,7 @@ function Notice({ children, dismiss, type, className }) {
         {type === 'warning' && <WarningIcon />}
         {children}
         {dismiss && (
-          <CloseButton
-            type={type}
-            onClick={() => dismissAnimationWrapper()}
-          >
+          <CloseButton type={type} onClick={() => dismissAnimationWrapper()}>
             <Cross />
           </CloseButton>
         )}

--- a/src/components/Notice/Notice.jsx
+++ b/src/components/Notice/Notice.jsx
@@ -23,12 +23,12 @@ const colorMap = {
 };
 
 const NoticeWrapper = styled.div`
-  border: ${(props) => `1px solid ${colorMap[props.type].border}`};
-  color: ${(props) => colorMap[props.type].color};
-  background: ${(props) => colorMap[props.type].background};
+  border: ${props => `1px solid ${colorMap[props.type].border}`};
+  color: ${props => colorMap[props.type].color};
+  background: ${props => colorMap[props.type].background};
   border-radius: ${borderRadius};
   font-size: ${fontSize};
-  padding: 16px ${({ dismiss }) => (dismiss ? '36px' : '16px')} 16px 16px;
+  padding: 16px ${({ dismiss }) => dismiss ? '36px' : '16px' } 16px 16px;
   display: flex;
   justify-content: flex-start;
   position: relative;
@@ -43,7 +43,7 @@ const WarningIcon = styled(Warning)`
 `;
 
 const CloseButton = styled.button`
-  color: ${(props) => colorMap[props.type].color};
+  color: ${props => colorMap[props.type].color};
   border: 0;
   background: 0;
   padding: 0;
@@ -53,42 +53,43 @@ const CloseButton = styled.button`
   position: absolute;
   right: 16px;
   &:hover {
-    color: ${(props) => colorMap[props.type].color};
+    color: ${props => colorMap[props.type].color};
     opacity: 1;
     cursor: pointer;
   }
 `;
 
 function Notice({ children, dismiss, type, className, disableAnimation }) {
-  const {
-    AnimationWrapper,
-    dismiss: dismissAnimationWrapper,
-    animationProps,
-  } = useAnimation({
+  const { AnimationWrapper, dismiss:dismissAnimationWrapper, animationProps } = useAnimation({
     justify: 'flex-end',
     stageInAnimation: stageInRight,
     stageOutAnimation: fadeOut,
     onDismiss: dismiss,
-  });
+  })
 
-  return (
-    <AnimationWrapper {...animationProps} disableAnimation={disableAnimation}>
-      <NoticeWrapper type={type} dismiss={dismiss} className={className}>
-        {type === 'warning' && <WarningIcon />}
-        {children}
-        {dismiss && (
-          <CloseButton type={type} onClick={() => dismissAnimationWrapper()}>
-            <Cross />
-          </CloseButton>
-        )}
-      </NoticeWrapper>
-    </AnimationWrapper>
+  const noticeContent = (
+    <NoticeWrapper type={type} dismiss={dismiss} className={className}>
+      {type === 'warning' && <WarningIcon />}
+      {children}
+      {dismiss && (
+        <CloseButton type={type} onClick={() => dismissAnimationWrapper()}>
+          <Cross />
+        </CloseButton>
+      )}
+    </NoticeWrapper>
   );
+
+  if (disableAnimation) {
+    return <>{noticeContent}</>;
+  }
+
+  return <AnimationWrapper {...animationProps}>{noticeContent}</AnimationWrapper>;
 }
 
 Notice.propTypes = {
   children: PropTypes.node.isRequired,
   dismiss: PropTypes.func,
+  /** doesn't use animation wrapper if true */
   disableAnimation: PropTypes.bool,
   /** can be warning, note */
   type: PropTypes.string.isRequired,
@@ -96,7 +97,7 @@ Notice.propTypes = {
 
 Notice.defaultProps = {
   dismiss: null,
-  disableAnimation: false,
+  disableAnimation: false
 };
 
 export default Notice;

--- a/src/components/Notice/__snapshots__/Notice.spec.js.snap
+++ b/src/components/Notice/__snapshots__/Notice.spec.js.snap
@@ -1,5 +1,67 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`jest-auto-snapshots > Notice Matches snapshot when boolean prop "disableAnimation" is set to: "false" 1`] = `
+<AnimationWrapper
+  align="center"
+  dismissing={false}
+  duration={300}
+  easing="cubic-bezier(0.25, 1, 0.5, 1)"
+  justify="flex-end"
+  onDismiss={[MockFunction]}
+  stageInAnimation={
+    e {
+      "id": "sc-keyframes-jALQVJ",
+      "inject": [Function],
+      "name": "jALQVJ",
+      "rules": "
+  0% {
+    transform: translateX(200px);
+    opacity: 0;
+  }
+
+  100% {
+    transform: translateX(0);
+    opacity: 1;
+  }
+",
+      "toString": [Function],
+    }
+  }
+  stageOutAnimation={
+    e {
+      "id": "sc-keyframes-bjhQjg",
+      "inject": [Function],
+      "name": "bjhQjg",
+      "rules": "
+  0% {
+    transform: scale(1) translateY(0);
+    opacity: 1;
+  }
+
+  100% {
+    transform: scale(1.05) translateY(-10px);
+    opacity: 0;
+  }
+",
+      "toString": [Function],
+    }
+  }
+>
+  <ForwardRef(styled.div)
+    dismiss={[MockFunction]}
+    type="jest-auto-snapshots String Fixture"
+  >
+    <NodeFixture />
+    <ForwardRef(styled.button)
+      onClick={[Function]}
+      type="jest-auto-snapshots String Fixture"
+    >
+      <CrossIcon />
+    </ForwardRef(styled.button)>
+  </ForwardRef(styled.div)>
+</AnimationWrapper>
+`;
+
 exports[`jest-auto-snapshots > Notice Matches snapshot when passed all props 1`] = `
 <AnimationWrapper
   align="center"

--- a/src/components/Notice/__snapshots__/Notice.spec.js.snap
+++ b/src/components/Notice/__snapshots__/Notice.spec.js.snap
@@ -63,52 +63,7 @@ exports[`jest-auto-snapshots > Notice Matches snapshot when boolean prop "disabl
 `;
 
 exports[`jest-auto-snapshots > Notice Matches snapshot when passed all props 1`] = `
-<AnimationWrapper
-  align="center"
-  dismissing={false}
-  duration={300}
-  easing="cubic-bezier(0.25, 1, 0.5, 1)"
-  justify="flex-end"
-  onDismiss={[MockFunction]}
-  stageInAnimation={
-    e {
-      "id": "sc-keyframes-jALQVJ",
-      "inject": [Function],
-      "name": "jALQVJ",
-      "rules": "
-  0% {
-    transform: translateX(200px);
-    opacity: 0;
-  }
-
-  100% {
-    transform: translateX(0);
-    opacity: 1;
-  }
-",
-      "toString": [Function],
-    }
-  }
-  stageOutAnimation={
-    e {
-      "id": "sc-keyframes-bjhQjg",
-      "inject": [Function],
-      "name": "bjhQjg",
-      "rules": "
-  0% {
-    transform: scale(1) translateY(0);
-    opacity: 1;
-  }
-
-  100% {
-    transform: scale(1.05) translateY(-10px);
-    opacity: 0;
-  }
-",
-      "toString": [Function],
-    }
-  }
->
+<div>
   <ForwardRef(styled.div)
     dismiss={[MockFunction]}
     type="jest-auto-snapshots String Fixture"
@@ -121,7 +76,7 @@ exports[`jest-auto-snapshots > Notice Matches snapshot when passed all props 1`]
       <CrossIcon />
     </ForwardRef(styled.button)>
   </ForwardRef(styled.div)>
-</AnimationWrapper>
+</div>
 `;
 
 exports[`jest-auto-snapshots > Notice Matches snapshot when passed only required props 1`] = `

--- a/src/documentation/markdown/GettingStarted/CHANGELOG.md
+++ b/src/documentation/markdown/GettingStarted/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [6.1.0] - 2022-03-21
+- Notice component: add new `disableAnimation` prop
+- fix: updated AnimationWrapper component to use `prefers-reduced-motion`
+
 ## [6.0.1] - 2022-03-15
 - fixed: SimpleModal is dismissed on ESC keypress
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Update the AnimationWrapper and Notice components to include the option to disable animation.

## Description
<!--- Describe your changes in detail -->
- Add a new prop `disableAnimation` to the Notice component 
- Updated the css for the AnimationWrapper to include the `prefers-reduced-motion` media feature. This stop animations if the user has chosen to in their system. [[ref](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)]

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We want to disable the animation for the Notice on the Channels support page. Sometimes, it doesn’t make sense to have an animation. Especially when the Notice cannot be dismissed and the component re-renders several times.
[GROW-426](https://buffer.atlassian.net/browse/GROW-426)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style and guidelines of this project. <!--- Link to Standards file coming soon. -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the **CHANGELOG** document.
- [ ] I have added tests to cover my changes.
- [x] I have performed a self-review of my own code
- [x] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] All new and existing tests passed.
- [x] I have performed the accessibility audit of my UI changes according to the accessibility doc. <!--- Link to Accessibility Standards file coming soon. -->
- [ ] [Buffer Engineers] Someone from the Design team reviewed and approved my changes
- [ ] [Buffer Engineers] I have notified the BDS team of my changes in the #proj-design-system Slack channel
