### PR TITLE
Add the ability to pass a tooltip along with a Select item

### DIFF
--- a/src/components/Select/SelectItem/SelectItem.jsx
+++ b/src/components/Select/SelectItem/SelectItem.jsx
@@ -66,30 +66,30 @@ const SelectItem = ({
         hasComponent={item.component}
       >
         {item.selected && (
-        <IconWrapper>
-          <Checkmark color="grayDarker" />
-        </IconWrapper>
-      )}
+          <IconWrapper>
+            <Checkmark color="grayDarker" />
+          </IconWrapper>
+        )}
         {item.icon && (
-        <SelectItemIcon hovered={hovered}>{item.icon}</SelectItemIcon>
-      )}
+          <SelectItemIcon hovered={hovered}>{item.icon}</SelectItemIcon>
+        )}
 
         <SelectItemTitle
           moveRight={shouldItemMoveRight(item, hasSelectedItems, hideSearch)}
           title={title}
         >
           {item.component && (
-          <IconWrapper custom>
-            <SelectItemCustom
-              dangerouslySetInnerHTML={{ __html: item.component(item) }}
-            />
-          </IconWrapper>
-        )}
+            <IconWrapper custom>
+              <SelectItemCustom
+                dangerouslySetInnerHTML={{ __html: item.component(item) }}
+              />
+            </IconWrapper>
+          )}
           <Title>{item[keyMap ? keyMap.title : 'title']}</Title>
         </SelectItemTitle>
         {item.hotKeyPrompt && (
-        <HotKeyPrompt hovered={hovered}>{item.hotKeyPrompt}</HotKeyPrompt>
-      )}
+          <HotKeyPrompt hovered={hovered}>{item.hotKeyPrompt}</HotKeyPrompt>
+        )}
       </SelectItemLabel>
     </SelectItemStyled>
   )

--- a/src/components/Select/SelectItem/SelectItem.jsx
+++ b/src/components/Select/SelectItem/SelectItem.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Checkmark } from '../../Icon';
+import Tooltip from '../../Tooltip';
 import {
   SelectItemStyled,
   SelectItemLabel,
@@ -19,6 +20,23 @@ const shouldItemMoveRight = (item, hasSelectedItems, hideSearch) =>
   // if it's not selected and it has a custom component, we shouldn't move the item
   !(item.component && !hasSelectedItems);
 
+const SelectItemTooltipWrapper = (props) => {
+  const { item, keyMap } = props;
+  const tooltip = item[keyMap ? keyMap.tooltip : 'tooltip']
+
+  return (
+    <>
+      {tooltip ? (
+        <Tooltip label={tooltip} position="bottom">
+          <SelectItem {...props} />
+        </Tooltip>
+      ) : (
+        <SelectItem {...props} />
+      )}
+    </>
+  )
+};
+
 const SelectItem = ({
   item,
   onClick,
@@ -29,47 +47,53 @@ const SelectItem = ({
   hideSearch,
   capitalizeItemLabel,
   onItemClick,
-}) => (
-  <SelectItemStyled
-    onClick={onItemClick || onClick}
-    hovered={hovered}
-    id={getItemId(item)}
-    disabled={item.disabled}
-  >
-    <SelectItemLabel
-      capitalizeItemLabel={capitalizeItemLabel}
-      hideSearch={hideSearch}
-      hasSelectedItems={hasSelectedItems}
-      hasComponent={item.component}
+}) => {
+  const tooltip = item[keyMap ? keyMap.tooltip : 'tooltip']
+  let title = item[keyMap ? keyMap.title : 'title'];;
+  if (tooltip) title = null;
+
+  return (
+    <SelectItemStyled
+      onClick={onItemClick || onClick}
+      hovered={hovered}
+      id={getItemId(item)}
+      disabled={item.disabled}
     >
-      {item.selected && (
+      <SelectItemLabel
+        capitalizeItemLabel={capitalizeItemLabel}
+        hideSearch={hideSearch}
+        hasSelectedItems={hasSelectedItems}
+        hasComponent={item.component}
+      >
+        {item.selected && (
         <IconWrapper>
           <Checkmark color="grayDarker" />
         </IconWrapper>
       )}
-      {item.icon && (
+        {item.icon && (
         <SelectItemIcon hovered={hovered}>{item.icon}</SelectItemIcon>
       )}
 
-      <SelectItemTitle
-        moveRight={shouldItemMoveRight(item, hasSelectedItems, hideSearch)}
-        title={item[keyMap ? keyMap.title : 'title']}
-      >
-        {item.component && (
+        <SelectItemTitle
+          moveRight={shouldItemMoveRight(item, hasSelectedItems, hideSearch)}
+          title={title}
+        >
+          {item.component && (
           <IconWrapper custom>
             <SelectItemCustom
               dangerouslySetInnerHTML={{ __html: item.component(item) }}
             />
           </IconWrapper>
         )}
-        <Title>{item[keyMap ? keyMap.title : 'title']}</Title>
-      </SelectItemTitle>
-      {item.hotKeyPrompt && (
+          <Title>{item[keyMap ? keyMap.title : 'title']}</Title>
+        </SelectItemTitle>
+        {item.hotKeyPrompt && (
         <HotKeyPrompt hovered={hovered}>{item.hotKeyPrompt}</HotKeyPrompt>
       )}
-    </SelectItemLabel>
-  </SelectItemStyled>
-);
+      </SelectItemLabel>
+    </SelectItemStyled>
+  )
+};
 
 SelectItem.propTypes = {
   /** Item to render */
@@ -80,6 +104,7 @@ SelectItem.propTypes = {
     selected: PropTypes.bool,
     icon: PropTypes.node,
     component: PropTypes.func,
+    tooltip: PropTypes.string,
   }).isRequired,
 
   /** On click function */
@@ -122,4 +147,4 @@ SelectItem.defaultProps = {
   capitalizeItemLabel: true,
 };
 
-export default SelectItem;
+export default SelectItemTooltipWrapper;

--- a/src/components/Select/__snapshots__/Select.spec.js.snap
+++ b/src/components/Select/__snapshots__/Select.spec.js.snap
@@ -30,7 +30,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when array prop "hotKeys"
     yPosition="top"
   >
     <ForwardRef(styled.ul)>
-      <SelectItem
+      <SelectItemTooltipWrapper
         capitalizeItemLabel={true}
         getItemId={[Function]}
         hasSelectedItems={false}
@@ -88,7 +88,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when array prop "hotKeys"
     yPosition="top"
   >
     <ForwardRef(styled.ul)>
-      <SelectItem
+      <SelectItemTooltipWrapper
         capitalizeItemLabel={true}
         getItemId={[Function]}
         hasSelectedItems={false}
@@ -146,7 +146,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when array prop "items" h
     yPosition="top"
   >
     <ForwardRef(styled.ul)>
-      <SelectItem
+      <SelectItemTooltipWrapper
         capitalizeItemLabel={true}
         getItemId={[Function]}
         hasSelectedItems={false}
@@ -204,7 +204,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "capita
     yPosition="top"
   >
     <ForwardRef(styled.ul)>
-      <SelectItem
+      <SelectItemTooltipWrapper
         capitalizeItemLabel={false}
         getItemId={[Function]}
         hasSelectedItems={false}
@@ -262,7 +262,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "clearS
     yPosition="top"
   >
     <ForwardRef(styled.ul)>
-      <SelectItem
+      <SelectItemTooltipWrapper
         capitalizeItemLabel={true}
         getItemId={[Function]}
         hasSelectedItems={false}
@@ -321,7 +321,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "disabl
     yPosition="top"
   >
     <ForwardRef(styled.ul)>
-      <SelectItem
+      <SelectItemTooltipWrapper
         capitalizeItemLabel={true}
         getItemId={[Function]}
         hasSelectedItems={false}
@@ -379,7 +379,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "fullWi
     yPosition="top"
   >
     <ForwardRef(styled.ul)>
-      <SelectItem
+      <SelectItemTooltipWrapper
         capitalizeItemLabel={true}
         getItemId={[Function]}
         hasSelectedItems={false}
@@ -437,7 +437,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "hasCus
     yPosition="top"
   >
     <ForwardRef(styled.ul)>
-      <SelectItem
+      <SelectItemTooltipWrapper
         capitalizeItemLabel={true}
         getItemId={[Function]}
         hasSelectedItems={false}
@@ -495,7 +495,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "hasIco
     yPosition="top"
   >
     <ForwardRef(styled.ul)>
-      <SelectItem
+      <SelectItemTooltipWrapper
         capitalizeItemLabel={true}
         getItemId={[Function]}
         hasSelectedItems={false}
@@ -553,7 +553,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "hideSe
     yPosition="top"
   >
     <ForwardRef(styled.ul)>
-      <SelectItem
+      <SelectItemTooltipWrapper
         capitalizeItemLabel={true}
         getItemId={[Function]}
         hasSelectedItems={false}
@@ -611,7 +611,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "isInpu
     yPosition="top"
   >
     <ForwardRef(styled.ul)>
-      <SelectItem
+      <SelectItemTooltipWrapper
         capitalizeItemLabel={true}
         getItemId={[Function]}
         hasSelectedItems={false}
@@ -669,7 +669,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "isOpen
     yPosition="top"
   >
     <ForwardRef(styled.ul)>
-      <SelectItem
+      <SelectItemTooltipWrapper
         capitalizeItemLabel={true}
         getItemId={[Function]}
         hasSelectedItems={false}
@@ -719,7 +719,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "isSpli
     yPosition="top"
   >
     <ForwardRef(styled.ul)>
-      <SelectItem
+      <SelectItemTooltipWrapper
         capitalizeItemLabel={true}
         getItemId={[Function]}
         hasSelectedItems={false}
@@ -777,7 +777,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "multiS
     yPosition="top"
   >
     <ForwardRef(styled.ul)>
-      <SelectItem
+      <SelectItemTooltipWrapper
         capitalizeItemLabel={true}
         getItemId={[Function]}
         hasSelectedItems={false}
@@ -835,7 +835,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "select
     yPosition="top"
   >
     <ForwardRef(styled.ul)>
-      <SelectItem
+      <SelectItemTooltipWrapper
         capitalizeItemLabel={true}
         getItemId={[Function]}
         hasSelectedItems={false}
@@ -893,7 +893,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "shortc
     yPosition="top"
   >
     <ForwardRef(styled.ul)>
-      <SelectItem
+      <SelectItemTooltipWrapper
         capitalizeItemLabel={true}
         getItemId={[Function]}
         hasSelectedItems={false}
@@ -951,7 +951,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when passed all props 1`]
     yPosition="top"
   >
     <ForwardRef(styled.ul)>
-      <SelectItem
+      <SelectItemTooltipWrapper
         capitalizeItemLabel={true}
         getItemId={[Function]}
         hasSelectedItems={false}
@@ -1019,7 +1019,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when passed only required
     yPosition="bottom"
   >
     <ForwardRef(styled.ul)>
-      <SelectItem
+      <SelectItemTooltipWrapper
         capitalizeItemLabel={true}
         getItemId={[Function]}
         hasSelectedItems={false}

--- a/src/documentation/examples/Select/SelectWithItemTooltip.jsx
+++ b/src/documentation/examples/Select/SelectWithItemTooltip.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import Select from '@bufferapp/ui/Select';
+
+/** With Item Tooltip */
+export default function ExampleSelect() {
+  return (
+    <Select
+      onSelectClick={() => true}
+      label="Click me"
+      type="primary"
+      items={[
+        { id: '1', title: 'Open' },
+        { id: '2', title: 'Pending', tooltip: 'Pending item tooltip' },
+        { id: '3', title: 'Closed' },
+      ]}
+      position="right"
+      hideSearch
+    />
+  );
+}

--- a/src/documentation/examples/Select/SelectWithItemTooltip.jsx
+++ b/src/documentation/examples/Select/SelectWithItemTooltip.jsx
@@ -9,9 +9,8 @@ export default function ExampleSelect() {
       label="Click me"
       type="primary"
       items={[
-        { id: '1', title: 'Open' },
-        { id: '2', title: 'Pending', tooltip: 'Pending item tooltip' },
-        { id: '3', title: 'Closed' },
+        { id: '1', title: 'With tooltip', tooltip: 'Item with tooltip' },
+        { id: '2', title: 'Without tooltip' },
       ]}
       position="right"
       hideSearch

--- a/src/documentation/markdown/GettingStarted/CHANGELOG.md
+++ b/src/documentation/markdown/GettingStarted/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- Add the ability to pass a tooltip as part of a Select item. It will display a tooltip instead of a title on hover.
+
 ## [6.1.0] - 2022-03-21
 - Notice component: add new `disableAnimation` prop
 - fix: updated AnimationWrapper component to use `prefers-reduced-motion`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- if a `tooltip` property is passed as part of a Select item, the value will be rendered in a Tooltip on hover instead of the item `title`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We need to render a tooltip for a specific select item to provide additional context around selecting the item.

## Screenshots (if appropriate):
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/22494582/159651251-2281b805-d60b-42e8-b024-0d16b748c5e5.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style and guidelines of this project. <!--- Link to Standards file coming soon. -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the **CHANGELOG** document.
- [x] I have added tests to cover my changes.
- [x] I have performed a self-review of my own code
- [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] All new and existing tests passed.
- [ ] I have performed the accessibility audit of my UI changes according to the accessibility doc. <!--- Link to Accessibility Standards file coming soon. -->
- [ ] [Buffer Engineers] Someone from the Design team reviewed and approved my changes
- [ ] [Buffer Engineers] I have notified the BDS team of my changes in the #proj-design-system Slack channel
