### PR TITLE
Only render tooltip if a label is provided

### DIFF
--- a/src/components/Tooltip/Tooltip.jsx
+++ b/src/components/Tooltip/Tooltip.jsx
@@ -104,24 +104,34 @@ class Tooltip extends React.Component {
   render() {
     const { children, label, position, verticalAlign, hotkey, customLabel, opacity } = this.props;
 
+    const renderTooltip = label || customLabel;
+
     // @todo: remove style from here and use the Styled component
     // We are currently adding the stylings with the style tag,
     // instead of the adding it in the Styled component
     // because we still need to figure out a way to load the css file
     // properly, and being able to use our customs styles.
     return (
-      <Styles.TooltipWrapper ref={node => this.tooltipWrapper = node}>
-        <Styles.TooltipStyled
-          label={this.renderLabel(label, hotkey, customLabel)}
-          position={(triggerRect, tooltipRect) => this.getTooltipPosition(triggerRect, tooltipRect, position, verticalAlign)}
-          style={Styles.TooltipStyle}
-          opacity={opacity}
-        >
+      <div>
+        {renderTooltip ? (
+          <Styles.TooltipWrapper ref={node => this.tooltipWrapper = node}>
+            <Styles.TooltipStyled
+              label={this.renderLabel(label, hotkey, customLabel)}
+              position={(triggerRect, tooltipRect) => this.getTooltipPosition(triggerRect, tooltipRect, position, verticalAlign)}
+              style={Styles.TooltipStyle}
+              opacity={opacity}
+            >
+              <div>
+                {children}
+              </div>
+            </Styles.TooltipStyled>
+          </Styles.TooltipWrapper>
+        ) : (
           <div>
             {children}
           </div>
-        </Styles.TooltipStyled>
-      </Styles.TooltipWrapper>
+        )}
+      </div>
     )
   }
 }

--- a/src/components/Tooltip/__snapshots__/Tooltip.spec.js.snap
+++ b/src/components/Tooltip/__snapshots__/Tooltip.spec.js.snap
@@ -1,77 +1,55 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`jest-auto-snapshots > Tooltip Matches snapshot when passed all props 1`] = `
-<ForwardRef(styled.div)>
-  <ForwardRef(Styled(Tooltip))
-    label={
-      <ForwardRef(styled.div)>
-        <ForwardRef(styled.label)
-          color="#FFFFFF"
-        >
-          <ForwardRef(styled.div)>
-            jest-auto-snapshots String Fixture
-            <ForwardRef(styled.label)
-              color="#B8B8B8"
-              isHotkey={true}
-            >
+<div>
+  <ForwardRef(styled.div)>
+    <ForwardRef(Styled(Tooltip))
+      label={
+        <ForwardRef(styled.div)>
+          <ForwardRef(styled.label)
+            color="#FFFFFF"
+          >
+            <ForwardRef(styled.div)>
               jest-auto-snapshots String Fixture
-            </ForwardRef(styled.label)>
-          </ForwardRef(styled.div)>
-        </ForwardRef(styled.label)>
-        <NodeFixture />
-      </ForwardRef(styled.div)>
-    }
-    opacity={1}
-    position={[Function]}
-    style={
-      Object {
-        "background": "#3D3D3D",
-        "border": "none",
-        "borderRadius": "4px",
-        "color": "#FFFFFF",
-        "maxWidth": "200px",
-        "padding": "8px",
-        "position": "absolute",
-        "whiteSpace": "normal",
-        "zIndex": 9999,
+              <ForwardRef(styled.label)
+                color="#B8B8B8"
+                isHotkey={true}
+              >
+                jest-auto-snapshots String Fixture
+              </ForwardRef(styled.label)>
+            </ForwardRef(styled.div)>
+          </ForwardRef(styled.label)>
+          <NodeFixture />
+        </ForwardRef(styled.div)>
       }
-    }
-  >
-    <div>
-      <NodeFixture />
-    </div>
-  </ForwardRef(Styled(Tooltip))>
-</ForwardRef(styled.div)>
+      opacity={1}
+      position={[Function]}
+      style={
+        Object {
+          "background": "#3D3D3D",
+          "border": "none",
+          "borderRadius": "4px",
+          "color": "#FFFFFF",
+          "maxWidth": "200px",
+          "padding": "8px",
+          "position": "absolute",
+          "whiteSpace": "normal",
+          "zIndex": 9999,
+        }
+      }
+    >
+      <div>
+        <NodeFixture />
+      </div>
+    </ForwardRef(Styled(Tooltip))>
+  </ForwardRef(styled.div)>
+</div>
 `;
 
 exports[`jest-auto-snapshots > Tooltip Matches snapshot when passed only required props 1`] = `
-<ForwardRef(styled.div)>
-  <ForwardRef(Styled(Tooltip))
-    label={
-      <ForwardRef(styled.div)>
-        
-        
-      </ForwardRef(styled.div)>
-    }
-    opacity={1}
-    position={[Function]}
-    style={
-      Object {
-        "background": "#3D3D3D",
-        "border": "none",
-        "borderRadius": "4px",
-        "color": "#FFFFFF",
-        "maxWidth": "200px",
-        "padding": "8px",
-        "position": "absolute",
-        "whiteSpace": "normal",
-        "zIndex": 9999,
-      }
-    }
-  >
-    <div>
-      <NodeFixture />
-    </div>
-  </ForwardRef(Styled(Tooltip))>
-</ForwardRef(styled.div)>
+<div>
+  <div>
+    <NodeFixture />
+  </div>
+</div>
 `;

--- a/src/documentation/examples/Tooltip/visibility/notVisible.jsx
+++ b/src/documentation/examples/Tooltip/visibility/notVisible.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import Tooltip from '@bufferapp/ui/Tooltip';
+import Avatar from '@bufferapp/ui/Avatar'; // eslint-disable-line
+
+/** Not visible */
+export default function ExampleTooltip() {
+    return (
+      <Tooltip>
+        <Avatar
+          src="https://s3.amazonaws.com/buffer-ui/Default+Avatar.png"
+          alt="@joelgascoigne"
+          size="medium"
+        />
+      </Tooltip>
+    )
+}

--- a/src/documentation/examples/Tooltip/visibility/visible.jsx
+++ b/src/documentation/examples/Tooltip/visibility/visible.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import Tooltip from '@bufferapp/ui/Tooltip';
+import Avatar from '@bufferapp/ui/Avatar'; // eslint-disable-line
+
+/** Visible */
+export default function ExampleTooltip() {
+    return (
+      <Tooltip label="Visible tooltip">
+        <Avatar
+          src="https://s3.amazonaws.com/buffer-ui/Default+Avatar.png"
+          alt="@joelgascoigne"
+          size="medium"
+        />
+      </Tooltip>
+    )
+}

--- a/src/documentation/markdown/GettingStarted/CHANGELOG.md
+++ b/src/documentation/markdown/GettingStarted/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [Unreleased]
+- Changed tooltip component to only render if `label` or `customLabel` prop is provided
+
 ## [6.3.1] - 2022-03-30
 - NonDismissibleModal has different z-index than SimpleModal 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- only render tooltip component if a `label` or `customLabel` is provided
- add visibility examples for visible tooltip and not visible tooltip

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Because the tooltip is a wrapper, when a component conditionally needs a tooltip it's always a hassle to conditionally wrap it. This change allows you to only render the tooltip component if a label is provided. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style and guidelines of this project. <!--- Link to Standards file coming soon. -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have updated the **CHANGELOG** document.
- [ ] I have added tests to cover my changes.
- [x] I have performed a self-review of my own code
- [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] All new and existing tests passed.
- [ ] I have performed the accessibility audit of my UI changes according to the accessibility doc. <!--- Link to Accessibility Standards file coming soon. -->
- [ ] [Buffer Engineers] Someone from the Design team reviewed and approved my changes
- [ ] [Buffer Engineers] I have notified the BDS team of my changes in the #proj-design-system Slack channel
