### PR TITLE
fix: respect size setting on split Button

### DIFF
--- a/src/components/Button/Button.jsx
+++ b/src/components/Button/Button.jsx
@@ -119,6 +119,7 @@ const Button = ({
             onSelectClick={onSelectClick}
             items={items}
             type={type}
+            size={size}
             isSplit
             yPosition={selectPosition}
             xPosition="right"

--- a/src/components/Button/style.js
+++ b/src/components/Button/style.js
@@ -218,6 +218,10 @@ export const large = css`
   height: 48px;
 `;
 
+const Sizes = {
+  small, medium, large
+}
+
 /* state variants */
 export const disabled = css`
   background-color: ${grayLight};
@@ -243,12 +247,12 @@ export const ButtonSelect = style.div`
     width: 1px;
   }
 
+  ${props => Sizes[props.size] || Sizes.medium};
   align-items: center;
   display: flex;
-  height: 38px;
   justify-content: center;
   box-sizing: border-box;
-  padding: 0 10px;
+  ${props => props.size === 'small' ? 'padding: 0 6px'  : 'padding 0 10px'};
   position: relative;
   width: 100%;
 

--- a/src/components/Select/Select.jsx
+++ b/src/components/Select/Select.jsx
@@ -428,6 +428,7 @@ export default class Select extends React.Component {
       return (
         <ButtonSelect
           type={type}
+          size={size}
           disabled={disabled}
           onClick={!disabled ? this.onButtonClick : undefined}
         >

--- a/src/components/Select/__snapshots__/Select.spec.js.snap
+++ b/src/components/Select/__snapshots__/Select.spec.js.snap
@@ -14,6 +14,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when array prop "hotKeys"
 >
   <ForwardRef(styled.div)
     disabled={true}
+    size="small"
     type="primary"
   >
     <ChevronDownIcon
@@ -72,6 +73,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when array prop "hotKeys"
 >
   <ForwardRef(styled.div)
     disabled={true}
+    size="small"
     type="primary"
   >
     <ChevronDownIcon
@@ -130,6 +132,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when array prop "items" h
 >
   <ForwardRef(styled.div)
     disabled={true}
+    size="small"
     type="primary"
   >
     <ChevronDownIcon
@@ -188,6 +191,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "capita
 >
   <ForwardRef(styled.div)
     disabled={true}
+    size="small"
     type="primary"
   >
     <ChevronDownIcon
@@ -246,6 +250,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "clearS
 >
   <ForwardRef(styled.div)
     disabled={true}
+    size="small"
     type="primary"
   >
     <ChevronDownIcon
@@ -305,6 +310,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "disabl
   <ForwardRef(styled.div)
     disabled={false}
     onClick={[Function]}
+    size="small"
     type="primary"
   >
     <ChevronDownIcon
@@ -363,6 +369,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "fullWi
 >
   <ForwardRef(styled.div)
     disabled={true}
+    size="small"
     type="primary"
   >
     <ChevronDownIcon
@@ -421,6 +428,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "hasCus
 >
   <ForwardRef(styled.div)
     disabled={true}
+    size="small"
     type="primary"
   >
     <ChevronDownIcon
@@ -479,6 +487,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "hasIco
 >
   <ForwardRef(styled.div)
     disabled={true}
+    size="small"
     type="primary"
   >
     <ChevronDownIcon
@@ -537,6 +546,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "hideSe
 >
   <ForwardRef(styled.div)
     disabled={true}
+    size="small"
     type="primary"
   >
     <ChevronDownIcon
@@ -595,6 +605,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "isInpu
 >
   <ForwardRef(styled.div)
     disabled={true}
+    size="small"
     type="primary"
   >
     <ChevronDownIcon
@@ -653,6 +664,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "isOpen
 >
   <ForwardRef(styled.div)
     disabled={true}
+    size="small"
     type="primary"
   >
     <ChevronDownIcon
@@ -761,6 +773,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "multiS
 >
   <ForwardRef(styled.div)
     disabled={true}
+    size="small"
     type="primary"
   >
     <ChevronDownIcon
@@ -819,6 +832,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "select
 >
   <ForwardRef(styled.div)
     disabled={true}
+    size="small"
     type="primary"
   >
     <ChevronDownIcon
@@ -877,6 +891,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when boolean prop "shortc
 >
   <ForwardRef(styled.div)
     disabled={true}
+    size="small"
     type="primary"
   >
     <ChevronDownIcon
@@ -935,6 +950,7 @@ exports[`jest-auto-snapshots > Select Matches snapshot when passed all props 1`]
 >
   <ForwardRef(styled.div)
     disabled={true}
+    size="small"
     type="primary"
   >
     <ChevronDownIcon

--- a/src/documentation/examples/Button/Type/TypeSplitSmall.jsx
+++ b/src/documentation/examples/Button/Type/TypeSplitSmall.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import Button from '@bufferapp/ui/Button';
+
+/** Split Button (small) */
+export default function ExampleSplitButtonSmall() {
+  return (
+    <Button
+      onSelectClick={() => true}
+      onClick={() => true}
+      size="small"
+      type="primary"
+      isSplit
+      items={[
+        { id: '1', title: 'Reply + Pending' },
+        { id: '2', title: 'Reply + Close + Assign To Me' },
+      ]}
+      label="Click Me"
+    />
+  );
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

The `size` property was not being used on split buttons. Sofia noticed it in the Queue view in the webapp, and thought I would fix it here.

Before:
![image](https://user-images.githubusercontent.com/829971/168856148-2fa3eec2-344d-477c-9410-f988c7eac22c.png)

After: 
![image](https://user-images.githubusercontent.com/829971/168856292-bd86782b-0856-4bc4-9afa-7dce270d787f.png)


## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style and guidelines of this project. <!--- Link to Standards file coming soon. -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the **CHANGELOG** document.
- [ ] I have added tests to cover my changes.
- [ ] I have performed a self-review of my own code
- [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] All new and existing tests passed.
- [ ] I have performed the accessibility audit of my UI changes according to the accessibility doc. <!--- Link to Accessibility Standards file coming soon. -->
- [ ] [Buffer Engineers] Someone from the Design team reviewed and approved my changes
- [ ] [Buffer Engineers] I have notified the BDS team of my changes in the #proj-design-system Slack channel
