### PR TITLE
Support Icon for Input

### DIFF
--- a/src/components/Input/Input.jsx
+++ b/src/components/Input/Input.jsx
@@ -25,6 +25,7 @@ export default class Input extends React.Component {
       value,
       forwardedRef,
       required,
+      icon,
     } = this.props;
     return (
       <Styles.InputWrapper>
@@ -34,6 +35,7 @@ export default class Input extends React.Component {
           </Text>
         )}
         <Styles.InputFieldWrapper prefix={prefix} size={size}>
+          {icon && !prefix && <Styles.StyledIcon>{icon}</Styles.StyledIcon>}
           <Styles.InputStyled
             disabled={disabled}
             hasError={hasError}
@@ -50,7 +52,8 @@ export default class Input extends React.Component {
             value={value}
             ref={forwardedRef}
             required={required}
-            aria-required={required ? true: undefined}
+            aria-required={required ? true : undefined}
+            icon={icon}
           />
         </Styles.InputFieldWrapper>
         {help.length > 0 && (
@@ -102,6 +105,8 @@ Input.propTypes = {
   type: PropTypes.string,
   /** The value of the input */
   value: PropTypes.string,
+  /** The value of the icon */
+  icon: PropTypes.node,
   /**
    * this consumed by the default export that is wrapping the component into a ForwardRef
    * @ignore
@@ -125,4 +130,5 @@ Input.defaultProps = {
   forwardedRef: undefined,
   prefix: null,
   maxLength: undefined,
+  icon: undefined,
 };

--- a/src/components/Input/__snapshots__/Input.spec.js.snap
+++ b/src/components/Input/__snapshots__/Input.spec.js.snap
@@ -23,6 +23,7 @@ exports[`jest-auto-snapshots > Input Matches snapshot when boolean prop "disable
       aria-required={true}
       disabled={false}
       hasError={true}
+      icon={<NodeFixture />}
       id="jest-auto-snapshots String Fixture"
       maxLength="jest-auto-snapshots String Fixture"
       name="jest-auto-snapshots String Fixture"
@@ -80,6 +81,7 @@ exports[`jest-auto-snapshots > Input Matches snapshot when boolean prop "hasErro
       aria-required={true}
       disabled={true}
       hasError={false}
+      icon={<NodeFixture />}
       id="jest-auto-snapshots String Fixture"
       maxLength="jest-auto-snapshots String Fixture"
       name="jest-auto-snapshots String Fixture"
@@ -133,6 +135,7 @@ exports[`jest-auto-snapshots > Input Matches snapshot when boolean prop "require
     <ForwardRef(styled.input)
       disabled={true}
       hasError={true}
+      icon={<NodeFixture />}
       id="jest-auto-snapshots String Fixture"
       maxLength="jest-auto-snapshots String Fixture"
       name="jest-auto-snapshots String Fixture"
@@ -190,6 +193,7 @@ exports[`jest-auto-snapshots > Input Matches snapshot when passed all props 1`] 
       aria-required={true}
       disabled={true}
       hasError={true}
+      icon={<NodeFixture />}
       id="jest-auto-snapshots String Fixture"
       maxLength="jest-auto-snapshots String Fixture"
       name="jest-auto-snapshots String Fixture"

--- a/src/components/Input/style.js
+++ b/src/components/Input/style.js
@@ -76,6 +76,7 @@ export const InputStyled = styled.input`
   width: 100%;
 
   ${({ prefix }) => (prefix ? `padding-left: ${prefix.paddingLeft};` : '')}
+  ${({ icon }) => (icon ? `padding-left: 32px;` : '')}
 
   &::placeholder {
     color: ${grayDark};
@@ -112,5 +113,13 @@ export const HelpTextWrapper = styled.div`
 `;
 
 export const HelpText = styled(Text)`
-  margin-left: ${props => (props.hasError ? '8px' : '0px')};
+  margin-left: ${(props) => (props.hasError ? '8px' : '0px')};
+`;
+
+export const StyledIcon = styled.div`
+  position: absolute;
+  left: 8px;
+  top: 50%;
+  transform: translate(0, -50%);
+  display: flex;
 `;

--- a/src/documentation/examples/Input/option/WithIcon.jsx
+++ b/src/documentation/examples/Input/option/WithIcon.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import Input from '@bufferapp/ui/Input';
+import SearchIcon from '@bufferapp/ui/Icon/Icons/Search';
+
+/** Input with icon */
+export default function ExampleInput() {
+  return (
+    <Input
+      onChange={() => {}}
+      name="foo"
+      placeholder="Search channels"
+      icon={<SearchIcon size="large" />}
+    />
+  );
+}

--- a/src/documentation/markdown/GettingStarted/CHANGELOG.md
+++ b/src/documentation/markdown/GettingStarted/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [7.4.0] - 2022-08-22
+- Support icon for Input
+
 ## [7.3.0] - 2022-08-19
 - Add icon: Behance
 - Add icon: Substack


### PR DESCRIPTION
## Description
As in the title. Use an Icon component inside the Input, in the same way you can use a prefix text.

<img width="512" alt="CleanShot 2022-08-22 at 07 18 24@2x" src="https://user-images.githubusercontent.com/2612865/185844629-47478b61-3d7a-4801-afd9-763c669b1f71.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style and guidelines of this project. <!--- Link to Standards file coming soon. -->
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have updated the **CHANGELOG** document.
- [ ] I have added tests to cover my changes.
- [X] I have performed a self-review of my own code
- [X] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] All new and existing tests passed.
- [ ] I have performed the accessibility audit of my UI changes according to the accessibility doc. <!--- Link to Accessibility Standards file coming soon. -->
- [ ] [Buffer Engineers] Someone from the Design team reviewed and approved my changes
- [ ] [Buffer Engineers] I have notified the BDS team of my changes in the #proj-design-system Slack channel
