### PR TITLE
Fix Modal component not taking custom width

### DIFF
--- a/src/components/Modal/style.js
+++ b/src/components/Modal/style.js
@@ -36,7 +36,7 @@ const getWidth = props => {
     return '730px';
   }
   if (props.width) {
-    return props.customWidth;
+    return props.width;
   }
   return '512px';
 };

--- a/src/documentation/markdown/GettingStarted/CHANGELOG.md
+++ b/src/documentation/markdown/GettingStarted/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## [7.13.2] - 2022-11-28
+- Fix custom width on Modal
+
 ## [7.13.1] - 2022-11-19
 - Fix NavBarChavron alignment
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The `width` prop on the Modal component was not working as expected. Looks like we just had the wrong name for the width prop.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style and guidelines of this project. <!--- Link to Standards file coming soon. -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the **CHANGELOG** document.
- [ ] I have added tests to cover my changes.
- [ ] I have performed a self-review of my own code
- [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] All new and existing tests passed.
- [ ] I have performed the accessibility audit of my UI changes according to the accessibility doc. <!--- Link to Accessibility Standards file coming soon. -->
- [ ] [Buffer Engineers] Someone from the Design team reviewed and approved my changes
- [ ] [Buffer Engineers] I have notified the BDS team of my changes in the #proj-design-system Slack channel
