### PR TITLE
Fix Notice Dismiss

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufferapp/ui-template",
-  "version": "7.32.0",
+  "version": "7.32.1",
   "engines": {
     "node": ">=4.0.0"
   },

--- a/src/components/Notice/Notice.jsx
+++ b/src/components/Notice/Notice.jsx
@@ -103,6 +103,11 @@ function Notice({ children, dismiss, type, className, disableAnimation }) {
     onDismiss: dismiss,
   });
 
+  if (disableAnimation) {
+    delete animationProps.stageInAnimation;
+    delete animationProps.stageOutAnimation;
+  }
+
   const noticeContent = (
     <NoticeWrapper type={type} dismiss={dismiss} className={className}>
       {type === 'warning' && <WarningIcon />}
@@ -117,13 +122,9 @@ function Notice({ children, dismiss, type, className, disableAnimation }) {
     </NoticeWrapper>
   );
 
-  if (!disableAnimation) {
-    return (
-      <AnimationWrapper {...animationProps}>{noticeContent}</AnimationWrapper>
-    );
-  }
-
-  return <div>{noticeContent}</div>;
+  return (
+    <AnimationWrapper {...animationProps}>{noticeContent}</AnimationWrapper>
+  );
 }
 
 Notice.propTypes = {

--- a/src/components/Notice/Notice.jsx
+++ b/src/components/Notice/Notice.jsx
@@ -103,6 +103,9 @@ function Notice({ children, dismiss, type, className, disableAnimation }) {
     onDismiss: dismiss,
   });
 
+  // We always need to wrap the Notice with AnimationWrapper because the dismiss function
+  // shows the Notice based on the dismissed property. If the animation is disabled the properties
+  // that control the animation are removed from animationProps.
   if (disableAnimation) {
     delete animationProps.stageInAnimation;
     delete animationProps.stageOutAnimation;

--- a/src/components/Notice/Notice.jsx
+++ b/src/components/Notice/Notice.jsx
@@ -92,24 +92,19 @@ const CloseButton = styled.button`
 `;
 
 function Notice({ children, dismiss, type, className, disableAnimation }) {
+  // We always need to wrap the Notice with AnimationWrapper because the dismiss function
+  // shows the Notice based on the dismissed property. If the animation is disabled the properties
+  // that control the animation are removed from animationProps.
   const {
     AnimationWrapper,
     dismiss: dismissAnimationWrapper,
     animationProps,
   } = useAnimation({
     justify: 'flex-end',
-    stageInAnimation: stageInRight,
-    stageOutAnimation: fadeOut,
+    stageInAnimation: disableAnimation ? undefined : stageInRight,
+    stageOutAnimation: disableAnimation ? undefined : fadeOut,
     onDismiss: dismiss,
   });
-
-  // We always need to wrap the Notice with AnimationWrapper because the dismiss function
-  // shows the Notice based on the dismissed property. If the animation is disabled the properties
-  // that control the animation are removed from animationProps.
-  if (disableAnimation) {
-    delete animationProps.stageInAnimation;
-    delete animationProps.stageOutAnimation;
-  }
 
   const noticeContent = (
     <NoticeWrapper type={type} dismiss={dismiss} className={className}>

--- a/src/components/Notice/__snapshots__/Notice.spec.js.snap
+++ b/src/components/Notice/__snapshots__/Notice.spec.js.snap
@@ -63,7 +63,14 @@ exports[`jest-auto-snapshots > Notice Matches snapshot when boolean prop "disabl
 `;
 
 exports[`jest-auto-snapshots > Notice Matches snapshot when passed all props 1`] = `
-<div>
+<AnimationWrapper
+  align="center"
+  dismissing={false}
+  duration={300}
+  easing="cubic-bezier(0.25, 1, 0.5, 1)"
+  justify="flex-end"
+  onDismiss={[MockFunction]}
+>
   <ForwardRef(styled.div)
     dismiss={[MockFunction]}
     type="jest-auto-snapshots String Fixture"
@@ -76,7 +83,7 @@ exports[`jest-auto-snapshots > Notice Matches snapshot when passed all props 1`]
       <CrossIcon />
     </ForwardRef(styled.button)>
   </ForwardRef(styled.div)>
-</div>
+</AnimationWrapper>
 `;
 
 exports[`jest-auto-snapshots > Notice Matches snapshot when passed only required props 1`] = `

--- a/src/documentation/examples/Notice/NoticeDismissableNoAnimation.jsx
+++ b/src/documentation/examples/Notice/NoticeDismissableNoAnimation.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import Notice from '@bufferapp/ui/Notice';
+import Text from '@bufferapp/ui/Text';
+
+/** Notice Dismissable without Animation */
+export default function ExampleNotice() {
+  return (
+    // eslint-disable-next-line
+    <Notice
+      dismiss={() => console.log('dismissed!')}
+      type="note"
+      disableAnimation
+    >
+      <Text>
+        We&apos;re actively working on improving this feature and would love
+        your feedback!
+      </Text>
+    </Notice>
+  );
+}

--- a/src/documentation/markdown/GettingStarted/CHANGELOG.md
+++ b/src/documentation/markdown/GettingStarted/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [7.32.1] - 2023-02-01
+- Fix: Notice not dismissable if disabling animation
+
 ## [7.32.0] - 2023-01-19
 
 - Add default type definitions for `@bufferapp/ui` package


### PR DESCRIPTION
## Description
If you set `disableAnimation` to the `Notice` component, you cannot dismiss the notice because it relies on the `AnimationWrapper` to hide the Notice. This PR removes the animation properties before sharing them to the `AnimationWrapper`.

## Motivation and Context
We are using the Notice component to create a banner in Mastodon Profile pages to encourage customers to follow Buffer.

<img width="878" alt="CleanShot 2023-02-01 at 16 19 21" src="https://user-images.githubusercontent.com/2612865/216107247-86dc7e86-a7e1-49c2-9b7e-88898748e34d.png">


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style and guidelines of this project. <!--- Link to Standards file coming soon. -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the **CHANGELOG** document.
- [ ] I have added tests to cover my changes.
- [ ] I have performed a self-review of my own code
- [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] All new and existing tests passed.
- [ ] I have performed the accessibility audit of my UI changes according to the accessibility doc. <!--- Link to Accessibility Standards file coming soon. -->
- [ ] [Buffer Engineers] Someone from the Design team reviewed and approved my changes
- [ ] [Buffer Engineers] I have notified the BDS team of my changes in the #proj-design-system Slack channel
