### PR TITLE
replace outdated Message icon with new icon

### DIFF
--- a/src/documentation/examples/Button/Type/TypePrimaryIcon.jsx
+++ b/src/documentation/examples/Button/Type/TypePrimaryIcon.jsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import Button from '@bufferapp/ui/Button';
-import { Message } from '@bufferapp/ui/Icon';
+import { MessageFilled } from '@bufferapp/ui/Icon';
 
 /** Primary with Icon */
 export default function ExampleButton() {
   return (
     <Button
       type="primary"
-      icon={<Message color="white" />}
+      icon={<MessageFilled color="white" />}
       onClick={() => {}}
       label="Click Me"
     />

--- a/src/documentation/examples/Button/Type/TypePrimaryIconEnd.jsx
+++ b/src/documentation/examples/Button/Type/TypePrimaryIconEnd.jsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import Button from '@bufferapp/ui/Button';
-import { Message } from '@bufferapp/ui/Icon';
+import { MessageFilled } from '@bufferapp/ui/Icon';
 
 /** Primary with Icon */
 export default function ExampleButton() {
   return (
     <Button
       type="primary"
-      icon={<Message color="white" />}
+      icon={<MessageFilled color="white" />}
       iconEnd
       onClick={() => {}}
       label="Click Me"

--- a/src/documentation/markdown/GettingStarted/CHANGELOG.md
+++ b/src/documentation/markdown/GettingStarted/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [7.38.5] - 2023-03-09
+- fix: button documentation uses new MessageFilled icon
+
 ## [7.38.4] - 2023-03-06
 - Update cached icon data
 


### PR DESCRIPTION

## Description
We've added new message icons so we need to replace these in the Button examples so the page doesn't break


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style and guidelines of this project. <!--- Link to Standards file coming soon. -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the **CHANGELOG** document.
- [ ] I have added tests to cover my changes.
- [ ] I have performed a self-review of my own code
- [ ] I have tested my changes/additions in the latest Chrome, Firefox, and Safari.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] All new and existing tests passed.
- [ ] I have performed the accessibility audit of my UI changes according to the accessibility doc. <!--- Link to Accessibility Standards file coming soon. -->
- [ ] [Buffer Engineers] Someone from the Design team reviewed and approved my changes
- [ ] [Buffer Engineers] I have notified the BDS team of my changes in the #proj-design-system Slack channel
